### PR TITLE
Add support for retrieving the list of hostnames of the jov in slurm

### DIFF
--- a/submitit/core/job_environment.py
+++ b/submitit/core/job_environment.py
@@ -10,7 +10,7 @@ import socket
 import sys
 import types
 from pathlib import Path
-from typing import Any, ClassVar, Dict, Optional
+from typing import Any, ClassVar, Dict, List, Optional
 
 from . import logger, utils
 from .utils import DelayedSubmission, JobPaths
@@ -57,6 +57,14 @@ class JobEnvironment:
     @property
     def hostname(self) -> str:
         return socket.gethostname()
+
+    @property
+    def hostnames(self) -> List[str]:
+        env_key = "nodes"
+        if env_key not in self._env:
+            raise RuntimeError("Hostnames not available for the {self.cluster} cluster")
+        node_list = os.environ.get(self._env[env_key], "")
+        return self._parse_nodelist(node_list)
 
     @property
     def job_id(self) -> str:
@@ -136,6 +144,14 @@ class JobEnvironment:
             Use self.job_id to find what need to be requeued.
         """
         ...
+    
+    # pylint: disable=no-self-use,unused-argument
+    def _parse_nodelist(self, node_list: str) -> List[str]:
+        """Parse the content of the "nodes" environment variable,
+        which gives access to the list of hostnames that are part
+        of the current job.
+        """
+        return []
 
 
 class SignalHandler:


### PR DESCRIPTION
The SLURM workflow manager provides as environment variable the list of hostnames that are taking part in the job. The content of this environment variable follows a specific format that is not trivial to parse and tends to be partially implemented in many different projects. This pull request offers a valid implementation as part of the API.