### PR TITLE
Fix: Node list suffix parsing removes leading zeros

### DIFF
--- a/submitit/slurm/slurm.py
+++ b/submitit/slurm/slurm.py
@@ -132,8 +132,9 @@ def _expand_id_suffix(suffix_parts: str) -> List[str]:
     for suffix_part in suffix_parts.split(","):
         if "-" in suffix_part:
             low, high = suffix_part.split("-")
+            int_length = len(low)
             for num in range(int(low), int(high) + 1):
-                suffixes.append(str(num))
+                suffixes.append(f"{num:0{int_length}}")
         else:
             suffixes.append(suffix_part)
     return suffixes

--- a/submitit/slurm/test_slurm.py
+++ b/submitit/slurm/test_slurm.py
@@ -311,6 +311,15 @@ def test_slurm_node_list() -> None:
             "compute-b28",
             "compute-a1",
         ] == env.hostnames
+    with with_slurm_job_nodelist("compute[042,044]") as env:
+        assert ["compute042", "compute044"] == env.hostnames
+    with with_slurm_job_nodelist("compute[042-043,045,048-049]") as env:
+        assert ["compute042",
+                "compute043",
+                "compute045",
+                "compute048",
+                "compute049",
+        ] == env.hostnames
 
 
 def test_slurm_node_list_online_documentation() -> None:

--- a/submitit/slurm/test_slurm.py
+++ b/submitit/slurm/test_slurm.py
@@ -314,12 +314,7 @@ def test_slurm_node_list() -> None:
     with with_slurm_job_nodelist("compute[042,044]") as env:
         assert ["compute042", "compute044"] == env.hostnames
     with with_slurm_job_nodelist("compute[042-043,045,048-049]") as env:
-        assert ["compute042",
-                "compute043",
-                "compute045",
-                "compute048",
-                "compute049",
-        ] == env.hostnames
+        assert ["compute042", "compute043", "compute045", "compute048", "compute049"] == env.hostnames
 
 
 def test_slurm_node_list_online_documentation() -> None:


### PR DESCRIPTION
* The .hostnames property in slurm job environment currently casts
the suffix ids to integers to expand the ranges. However, this
strips the leading zeros and returns invalid hostnames. This
commit fixes this

* Added a couple of tests to check for this as well