### PR TITLE
Allow generic overrides

### DIFF
--- a/submitit/auto/auto.py
+++ b/submitit/auto/auto.py
@@ -180,9 +180,8 @@ class AutoExecutor(Executor):
         # update parameters in the core executor
         for (ex, arg) in specific:
             # update cluster specific non-generic arguments
-            if arg in generics or ex != self.cluster:
-                continue
-            parameters[arg] = kwargs[f"{ex}_{arg}"]
+            if arg not in generics and ex == self.cluster:
+                parameters[arg] = kwargs[f"{ex}_{arg}"]
 
         self._executor._internal_update_parameters(**parameters)
 

--- a/submitit/auto/auto.py
+++ b/submitit/auto/auto.py
@@ -175,7 +175,13 @@ class AutoExecutor(Executor):
             raise NameError("\n".join(invalid))
 
         # add cluster specific generic overrides
-        kwargs.update(**{arg: kwargs.pop(f"{ex}_{arg}") for ex, arg in specific if ex == self.cluster and arg in generics})
+        kwargs.update(
+            **{
+                arg: kwargs.pop(f"{ex}_{arg}")
+                for ex, arg in specific
+                if ex == self.cluster and arg in generics
+            }
+        )
         parameters = self._executor._convert_parameters({k: kwargs[k] for k in kwargs if k in generics})
         # update parameters in the core executor
         for (ex, arg) in specific:

--- a/submitit/auto/auto.py
+++ b/submitit/auto/auto.py
@@ -163,7 +163,7 @@ class AutoExecutor(Executor):
                 continue
 
             valid = executors[ex]._valid_parameters()
-            if arg not in valid:
+            if arg not in valid | generics:
                 invalid.append(
                     f"Unknown argument '{arg}' for executor '{ex}' in parameter '{ex}_{arg}'."
                     + " Valid arguments: "
@@ -174,10 +174,13 @@ class AutoExecutor(Executor):
             invalid.append(f"Known executors: {', '.join(executors.keys())}")
             raise NameError("\n".join(invalid))
 
+        # add cluster specific generic overrides
+        kwargs.update(**{arg: kwargs.pop(f"{ex}_{arg}") for ex, arg in specific if ex == self.cluster and arg in generics})
         parameters = self._executor._convert_parameters({k: kwargs[k] for k in kwargs if k in generics})
         # update parameters in the core executor
         for (ex, arg) in specific:
-            if ex != self.cluster:
+            # update cluster specific non-generic arguments
+            if arg in generics or ex != self.cluster:
                 continue
             parameters[arg] = kwargs[f"{ex}_{arg}"]
 

--- a/submitit/auto/test_auto.py
+++ b/submitit/auto/test_auto.py
@@ -43,7 +43,6 @@ def test_local_executor() -> None:
     executor.update_parameters(local_cpus_per_task=2)
 
 
-
 def test_executor_argument() -> None:
     with test_slurm.mocked_slurm():
         executor = auto.AutoExecutor(folder=".", slurm_max_num_timeout=22)
@@ -81,8 +80,9 @@ def test_overriden_arguments() -> None:
     with test_slurm.mocked_slurm():
         slurm_ex = auto.AutoExecutor(folder=".", cluster="slurm")
 
-    slurm_ex.update_parameters(timeout_min=60, slurm_timeout_min=120,
-                               tasks_per_node=2, slurm_ntasks_per_node=3)
+    slurm_ex.update_parameters(
+        timeout_min=60, slurm_timeout_min=120, tasks_per_node=2, slurm_ntasks_per_node=3
+    )
     slurm_params = slurm_ex._executor.parameters
     # slurm use time
     assert slurm_params == {"time": 120, "ntasks_per_node": 3}

--- a/submitit/auto/test_auto.py
+++ b/submitit/auto/test_auto.py
@@ -40,6 +40,8 @@ def test_local_executor() -> None:
     with test_slurm.mocked_slurm():
         executor = auto.AutoExecutor(folder=".", cluster="local")
     assert executor.cluster == "local"
+    executor.update_parameters(local_cpus_per_task=2)
+
 
 
 def test_executor_argument() -> None:
@@ -79,10 +81,11 @@ def test_overriden_arguments() -> None:
     with test_slurm.mocked_slurm():
         slurm_ex = auto.AutoExecutor(folder=".", cluster="slurm")
 
-    slurm_ex.update_parameters(timeout_min=60, slurm_time=120)
+    slurm_ex.update_parameters(timeout_min=60, slurm_timeout_min=120,
+                               tasks_per_node=2, slurm_ntasks_per_node=3)
     slurm_params = slurm_ex._executor.parameters
     # slurm use time
-    assert slurm_params == {"time": 120}
+    assert slurm_params == {"time": 120, "ntasks_per_node": 3}
 
     # others use timeout_min
     local_ex = auto.AutoExecutor(folder=".", cluster="local")


### PR DESCRIPTION
This allows specifying`<cluster>_<generic_parameter>` to override a generic parameter for a specific cluster
Closes #3 