### PR TITLE
Warn instead of raising error when executor.batch() empty

### DIFF
--- a/submitit/core/core.py
+++ b/submitit/core/core.py
@@ -587,7 +587,8 @@ class Executor(abc.ABC):
             delayed_batch = self._delayed_batch
             self._delayed_batch = None
         if not delayed_batch:
-            raise RuntimeError('No submission happened during "with executor.batch()" context.')
+            warnings.warn('WARNING: No submission happened during "with executor.batch()" context.')
+            return
         jobs, submissions = zip(*delayed_batch)
         new_jobs = self._internal_process_submissions(submissions)
         for j, new_j in zip(jobs, new_jobs):

--- a/submitit/core/core.py
+++ b/submitit/core/core.py
@@ -587,8 +587,9 @@ class Executor(abc.ABC):
             delayed_batch = self._delayed_batch
             self._delayed_batch = None
         if not delayed_batch:
-            warnings.warn('No submission happened during "with executor.batch()" context.',
-                          category=RuntimeWarning)
+            warnings.warn(
+                'No submission happened during "with executor.batch()" context.', category=RuntimeWarning,
+            )
             return
         jobs, submissions = zip(*delayed_batch)
         new_jobs = self._internal_process_submissions(submissions)

--- a/submitit/core/core.py
+++ b/submitit/core/core.py
@@ -588,7 +588,7 @@ class Executor(abc.ABC):
             self._delayed_batch = None
         if not delayed_batch:
             warnings.warn(
-                'No submission happened during "with executor.batch()" context.', category=RuntimeWarning,
+                'No submission happened during "with executor.batch()" context.', category=RuntimeWarning
             )
             return
         jobs, submissions = zip(*delayed_batch)

--- a/submitit/core/core.py
+++ b/submitit/core/core.py
@@ -587,7 +587,8 @@ class Executor(abc.ABC):
             delayed_batch = self._delayed_batch
             self._delayed_batch = None
         if not delayed_batch:
-            warnings.warn('No submission happened during "with executor.batch()" context.', category=RuntimeWarning)
+            warnings.warn('No submission happened during "with executor.batch()" context.',
+                          category=RuntimeWarning)
             return
         jobs, submissions = zip(*delayed_batch)
         new_jobs = self._internal_process_submissions(submissions)

--- a/submitit/core/core.py
+++ b/submitit/core/core.py
@@ -587,7 +587,7 @@ class Executor(abc.ABC):
             delayed_batch = self._delayed_batch
             self._delayed_batch = None
         if not delayed_batch:
-            warnings.warn('WARNING: No submission happened during "with executor.batch()" context.')
+            warnings.warn('No submission happened during "with executor.batch()" context.', category=RuntimeWarning)
             return
         jobs, submissions = zip(*delayed_batch)
         new_jobs = self._internal_process_submissions(submissions)

--- a/submitit/core/test_core.py
+++ b/submitit/core/test_core.py
@@ -190,7 +190,7 @@ def test_fake_executor_batch(tmp_path: Path) -> None:
             job = executor.submit(_three_time, 8)
             job.job_id  # pylint: disable=pointless-statement
     # empty context
-    with pytest.raises(RuntimeError):
+    with pytest.raises(RuntimeWarning):
         with executor.batch():
             pass
     # multi context

--- a/submitit/core/test_core.py
+++ b/submitit/core/test_core.py
@@ -190,7 +190,7 @@ def test_fake_executor_batch(tmp_path: Path) -> None:
             job = executor.submit(_three_time, 8)
             job.job_id  # pylint: disable=pointless-statement
     # empty context
-    with pytest.raises(RuntimeWarning):
+    with pytest.warns(RuntimeWarning):
         with executor.batch():
             pass
     # multi context


### PR DESCRIPTION
I feel that warning the user instead of raising an error when no jobs are submitted inside `with executor.batch():` is better, because sometimes the user might want to submit jobs conditionally and this can result in a normal behaviour where no jobs are submitted.
Tested for a few days locally, seems to work well.