### PR TITLE
bump isort version to 5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,13 +27,13 @@ test_coverage:
 
 format:
 	$(BIN)python -m pre_commit
-	$(BIN)isort -rc $(CODE_AND_SETUP)
+	$(BIN)isort $(CODE_AND_SETUP)
 	$(BIN)black $(CODE_AND_SETUP)
 
 check_format:
 	# also formats setup.py
-	# $(BIN)isort -rc --diff $(CODE_AND_SETUP) && $(BIN)isort -rc --check $(CODE_AND_SETUP)
-	$(BIN)black --diff $(CODE_AND_SETUP) && $(BIN)black --check $(CODE_AND_SETUP)
+	$(BIN)isort --check --diff $(CODE_AND_SETUP)
+	$(BIN)black --check --diff $(CODE_AND_SETUP)
 
 mypy:
 	$(BIN)mypy --version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,8 @@ include_trailing_comma = true
 force_grid_wrap = 0
 use_parentheses = true
 line_length = 110
-skip_glob = [".git", "venv", ".mypy_cache"]
+skip_gitignore = true
+float_to_top = true
 
 [tool.pylint]
   [tool.pylint."MESSAGES CONTROL"]

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,8 +1,8 @@
 black==19.3b0
-isort[pyproject]>=4.3.21
-mypy>=0.730
+isort>=5.4.2
+mypy>=0.782
 pre-commit>=1.15.2
 pytest-cov>=2.6.1
 coverage[toml]>=5.1
 pytest>=4.3.0
-pylint>=2.5.0
+pylint>=2.6.0

--- a/submitit/core/plugins.py
+++ b/submitit/core/plugins.py
@@ -20,11 +20,11 @@ if TYPE_CHECKING:
 def _get_plugins() -> Tuple[List[Type["Executor"]], List["JobEnvironment"]]:
     # pylint: disable=cyclic-import,import-outside-toplevel
     # Load dynamically to avoid import cycle
-    from ..local import debug, local
-    from ..slurm import slurm
-
     # pkg_resources goes through all modules on import.
     import pkg_resources
+
+    from ..local import debug, local
+    from ..slurm import slurm
 
     # TODO: use sys.modules.keys() and importlib.resources to find the files
     # We load both kind of entry points at the same time because we have to go through all module files anyway.


### PR DESCRIPTION
* remove -rc flag (now default behavior)
* add float_to_top=true (to keep old behavior)
* bump pylint to 2.6 for compatibility

https://pycqa.github.io/isort/docs/upgrade_guides/5.0.0/

This is a followup of #15.