### PR TITLE
Register jobs which are unpickled

### DIFF
--- a/submitit/core/core.py
+++ b/submitit/core/core.py
@@ -493,6 +493,15 @@ class Job(tp.Generic[R]):
             if not self.watcher.is_done(self.job_id, mode="cache"):
                 self.cancel(check=False)
 
+    def __getstate__(self) -> tp.Dict[str, tp.Any]:
+        return self.__dict__  # for pickling (see __setstate__)
+
+    def __setstate__(self, state: tp.Dict[str, tp.Any]) -> None:
+        """Make sure jobs are registered when loaded from a pickle
+        """
+        self.__dict__.update(state)
+        self.watcher.register_job(self.job_id)
+
 
 _MSG = (
     "Interactions with jobs are not allowed within "

--- a/submitit/core/core.py
+++ b/submitit/core/core.py
@@ -500,7 +500,8 @@ class Job(tp.Generic[R]):
         """Make sure jobs are registered when loaded from a pickle
         """
         self.__dict__.update(state)
-        self.watcher.register_job(self.job_id)
+        if not self._tasks[0]:  # only register for task=0
+            self.watcher.register_job(self.job_id)
 
 
 _MSG = (

--- a/submitit/core/core.py
+++ b/submitit/core/core.py
@@ -180,8 +180,11 @@ class Job(tp.Generic[R]):
         self._start_time = _time.time()
         self._last_status_check = self._start_time  # for the "done()" method
         # register for state updates with watcher
-        if not tasks[0]:  # only register for task=0
-            self.watcher.register_job(job_id)
+        self._register_in_watcher()
+
+    def _register_in_watcher(self) -> None:
+        if not self._tasks[0]:  # only register for task=0
+            self.watcher.register_job(self.job_id)
 
     @property
     def job_id(self) -> str:
@@ -500,8 +503,7 @@ class Job(tp.Generic[R]):
         """Make sure jobs are registered when loaded from a pickle
         """
         self.__dict__.update(state)
-        if not self._tasks[0]:  # only register for task=0
-            self.watcher.register_job(self.job_id)
+        self._register_in_watcher()
 
 
 _MSG = (

--- a/submitit/core/test_core.py
+++ b/submitit/core/test_core.py
@@ -6,9 +6,9 @@
 
 # pylint: disable=redefined-outer-name
 import contextlib
+import pickle
 import sys
 import time
-import pickle
 from pathlib import Path
 from typing import Any, Iterator, List, Optional, Union
 from unittest.mock import patch

--- a/submitit/core/test_core.py
+++ b/submitit/core/test_core.py
@@ -202,15 +202,15 @@ def test_fake_executor_batch(tmp_path: Path) -> None:
 
 
 def test_unpickling_watcher_registration(tmp_path: Path) -> None:
-    default_test_job_id = "12"  # this is enfroced by the fake executor
     executor = FakeExecutor(folder=tmp_path)
     job = executor.submit(_three_time, 4)
+    original_job_id = job._job_id
     job._job_id = "007"
-    assert job.watcher._registered == {default_test_job_id}  # still holds the old job id
+    assert job.watcher._registered == {original_job_id}  # still holds the old job id
     pkl = pickle.dumps(job)
     newjob = pickle.loads(pkl)
     assert newjob.job_id == "007"
-    assert newjob.watcher._registered == {default_test_job_id, "007"}
+    assert newjob.watcher._registered == {original_job_id, "007"}
 
 
 if __name__ == "__main__":

--- a/submitit/core/test_core.py
+++ b/submitit/core/test_core.py
@@ -202,14 +202,15 @@ def test_fake_executor_batch(tmp_path: Path) -> None:
 
 
 def test_unpickling_watcher_registration(tmp_path: Path) -> None:
+    default_test_job_id = "12"  # this is enfroced by the fake executor
     executor = FakeExecutor(folder=tmp_path)
     job = executor.submit(_three_time, 4)
     job._job_id = "007"
-    assert job.watcher._registered == {"12"}  # still holds the old job id
+    assert job.watcher._registered == {default_test_job_id}  # still holds the old job id
     pkl = pickle.dumps(job)
     newjob = pickle.loads(pkl)
     assert newjob.job_id == "007"
-    assert newjob.watcher._registered == {"12", "007"}
+    assert newjob.watcher._registered == {default_test_job_id, "007"}
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Unpickling does not call `__init__` hence jobs are not automatically registered when reloaded. This PR makes sure they are.