### PR TITLE
Enter postmorterm when job raise in debug mode

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
 show_error_codes=True
 
-[mypy-cloudpickle,pytest,setuptools]
+[mypy-cloudpickle,ipdb,pytest,setuptools]
 ignore_missing_imports=True

--- a/submitit/local/debug.py
+++ b/submitit/local/debug.py
@@ -70,6 +70,19 @@ class DebugJob(Job[R]):
         os.environ["SUBMITIT_DEBUG_JOB_ID"] = self.job_id
         try:
             return [self._submission.result()]
+        except Exception as e:
+            print(e)
+            # Try to mimic `breakpoint()` behavior
+            # pylint: disable=import-outside-toplevel
+            if os.environ.get("PYTHONBREAKPOINT", "").startswith("ipdb"):
+                import ipdb  # pylint: disable=import-error
+
+                ipdb.post_mortem()
+            else:
+                import pdb
+
+                pdb.post_mortem()
+            raise
         finally:
             os.environ.pop("SUBMITIT_DEBUG_JOB_ID")
 


### PR DESCRIPTION
I've found this very helpful recently.
I start all my experiment with the debug executor, then in case of failure I'm directly dropped at the right place.
When things works as expected, I just switch to slurm executor and let it run on the cluster.

Ideally I'd like to check if `ipdb` is installed and use that when possible instead of `pdb`.