### PR TITLE
reload sys.path on job start #12

### DIFF
--- a/submitit/core/submission.py
+++ b/submitit/core/submission.py
@@ -5,6 +5,7 @@
 #
 
 import argparse
+import sys
 import time
 import traceback
 from pathlib import Path
@@ -42,6 +43,8 @@ def process_job(folder: Union[Path, str]) -> None:
         )
     try:
         delayed = utils.DelayedSubmission.load(paths.submitted_pickle)
+        logger.info(f"Set sys.path to {delayed.sys_path} like in the scheduler runtime.")
+        sys.path = delayed.sys_path
         env = job_environment.JobEnvironment()
         env._handle_signals(paths, delayed)
         result = delayed.result()

--- a/submitit/core/utils.py
+++ b/submitit/core/utils.py
@@ -117,6 +117,7 @@ class DelayedSubmission:
         self._result: Any = None
         self._done = False
         self.timeout_countdown: int = 0  # controlled in submission and execution
+        self.sys_path = list(sys.path)
 
     def result(self) -> Any:
         if not self._done:

--- a/submitit/test_pickle.py
+++ b/submitit/test_pickle.py
@@ -5,6 +5,9 @@
 #
 
 import pickle
+import subprocess
+import sys
+from pathlib import Path
 from weakref import ref
 
 import pytest
@@ -77,3 +80,28 @@ def test_submitit_respects_main(tmp_path):
     ex = LocalExecutor(tmp_path)
     j_main = ex.submit(get_main).result()
     assert main == j_main
+
+
+def test_submitit_respects_sys_path(tmp_path: Path):
+    # https://github.com/facebookincubator/submitit/issues/12
+    CUSTOM_CODE = f"""
+import submitit
+import sys
+from pathlib import Path
+
+def dump_sys_path(file):
+    Path(file).write_text("\\n".join(sys.path))
+
+dump_sys_path("{tmp_path}/scheduler_path.txt")
+ex = submitit.LocalExecutor("{tmp_path}/log")
+job = ex.submit(dump_sys_path, "{tmp_path}/job_path.txt")
+job.wait()
+
+"""
+    scheduler_py = tmp_path / "scheduler.py"
+    scheduler_py.write_text(CUSTOM_CODE)
+    subprocess.check_call([sys.executable, scheduler_py])
+    job_sys_path = (tmp_path / "job_path.txt").read_text()
+    scheduler_sys_path = (tmp_path / "scheduler_path.txt").read_text()
+
+    assert job_sys_path == scheduler_sys_path


### PR DESCRIPTION
I propose the following to solve #12 

I think that the less surprising behavior possible.
We restore sys.path to whatever it was when we created the job instance.

In practice the two paths only differs on the first entry, but I'm not sure we want to assert that.
The scheduler script generally has the folder of scheduler script as first entry while the submitted job has the current folder.

Ouput of `test_submitit_respects_sys_path` if you skip the sys.path reloading:

```
E         - /private/var/folders/db/tkc8c7p17xzgpf_kv6ybsdcdng_9j1/T/pytest-of-guw/pytest-81/test_submitit_respects_sys_pat0
E         + /Users/guw/Documents/github/submitit
E           /opt/homebrew/Cellar/python37/3.7.5_3/Frameworks/Python.framework/Versions/3.7/lib/python37.zip
E           /opt/homebrew/Cellar/python37/3.7.5_3/Frameworks/Python.framework/Versions/3.7/lib/python3.7
E           /opt/homebrew/Cellar/python37/3.7.5_3/Frameworks/Python.framework/Versions/3.7/lib/python3.7/lib-dynload
E           /Users/guw/Documents/github/submitit/venv/lib/python3.7/site-packages
E           /Users/guw/Documents/github/submitit
```
