### PR TITLE
Don't rely on signals for preemption/timeout detection.

### DIFF
--- a/submitit/conftest.py
+++ b/submitit/conftest.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 #
 
+import time
 from pathlib import Path
 
 import pytest
@@ -19,3 +20,16 @@ def executor(tmp_path: Path) -> LocalExecutor:
 @pytest.fixture(params=["a_0", "a 0", 'a"=0"', "a'; echo foo", r"a\=0", r"a\=", "a\n0"])
 def weird_tmp_path(request, tmp_path: Path) -> Path:
     return tmp_path / request.param
+
+
+@pytest.fixture()
+def fast_forward_clock(monkeypatch):
+    """Allows to go in the future."""
+    clock_time = [time.time()]
+
+    monkeypatch.setattr(time, "time", lambda: clock_time[0])
+
+    def _fast_forward(minutes: float):
+        clock_time[0] += minutes * 60
+
+    return _fast_forward

--- a/submitit/core/core.py
+++ b/submitit/core/core.py
@@ -738,12 +738,14 @@ class PicklingExecutor(Executor):
             A Job instance, providing access to the job information,
             including the output of the function once it is computed.
         """
+        eq_dict = self._equivalence_dict()
+        timeout_min = self.parameters.get(eq_dict["timeout_min"] if eq_dict else "timeout_min", 5)
         jobs = []
         for delayed in delayed_submissions:
             tmp_uuid = uuid.uuid4().hex
             pickle_path = utils.JobPaths.get_first_id_independent_folder(self.folder) / f"{tmp_uuid}.pkl"
             pickle_path.parent.mkdir(parents=True, exist_ok=True)
-            delayed.timeout_countdown = self.max_num_timeout
+            delayed.set_timeout(timeout_min, self.max_num_timeout)
             delayed.dump(pickle_path)
 
             self._throttle()

--- a/submitit/core/job_environment.py
+++ b/submitit/core/job_environment.py
@@ -191,6 +191,7 @@ class SignalHandler:
     def checkpoint_and_exit(
         self, signum: signal.Signals, frame: types.FrameType = None  # pylint:disable=unused-argument
     ) -> None:
+        # Note: no signal is actually bound to `checkpoint_and_exit` but this is used by plugins.
         self._logger.info(f"Caught signal {signal.Signals(signum).name} on {socket.gethostname()}")
 
         procid = self.env.global_rank

--- a/submitit/core/utils.py
+++ b/submitit/core/utils.py
@@ -13,7 +13,6 @@ import shutil
 import subprocess
 import sys
 import tarfile
-import time
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterator, List, Optional, Type, Union
 
@@ -103,7 +102,6 @@ class JobPaths:
         return f"{self.__class__.__name__}({self.folder})"
 
 
-# pylint: disable=too-many-instance-attributes
 class DelayedSubmission:
     """Object for specifying the function/callable call to submit and process later.
     This is only syntactic sugar to make sure everything is well formatted:
@@ -118,15 +116,12 @@ class DelayedSubmission:
         self.kwargs = kwargs
         self._result: Any = None
         self._done = False
-        self.timeout_min: int = 0
-        self.timeout_countdown: int = 0  # controlled in submission and execution
-        self._end_time: float = -1
+        self._timeout_min: int = 0
+        self._timeout_countdown: int = 0  # controlled in submission and execution
 
     def result(self) -> Any:
         if self._done:
             return self._result
-        if self.timeout_min > 0:
-            self._end_time = time.time() + self.timeout_min * 60
 
         self._result = self.function(*self.args, **self.kwargs)
         self._done = True
@@ -139,8 +134,8 @@ class DelayedSubmission:
         cloudpickle_dump(self, filepath)
 
     def set_timeout(self, timeout_min: int, max_num_timeout: int) -> None:
-        self.timeout_min = timeout_min
-        self.timeout_countdown = max_num_timeout
+        self._timeout_min = timeout_min
+        self._timeout_countdown = max_num_timeout
 
     @classmethod
     def load(cls: Type["DelayedSubmission"], filepath: Union[str, Path]) -> "DelayedSubmission":

--- a/submitit/slurm/slurm.py
+++ b/submitit/slurm/slurm.py
@@ -314,10 +314,11 @@ class SlurmExecutor(core.PicklingExecutor):
         # array
         folder = utils.JobPaths.get_first_id_independent_folder(self.folder)
         folder.mkdir(parents=True, exist_ok=True)
+        timeout_min = self.parameters.get("time", 5)
         pickle_paths = []
         for d in delayed_submissions:
             pickle_path = folder / f"{uuid.uuid4().hex}.pkl"
-            d.timeout_countdown = self.max_num_timeout
+            d.set_timeout(timeout_min, self.max_num_timeout)
             d.dump(pickle_path)
             pickle_paths.append(pickle_path)
         n = len(delayed_submissions)


### PR DESCRIPTION
It seems that Slurm 20.02 has changed how it signals preemption to the running jobs compared to 19.05.
Before preemption was signaled by sigterm then sigusr1, while timeout was signaled by sigusr1.
Internal ticket T83385465

In this PR we don't rely anymore on signals. Instead we store the `timeout_min` in the DelayedSubmission and compute an `end_time` when `DelayedSubmission.result` is called.
If the submission is interrupted while working then we can look at the current time vs `end_time` and decide if the job was preempted or timed_out.

* Cons: complexifies DelayedSubmission
  * Pros: since DelayedSubmission was already handling the `timeout_countdown` logic (how many time a job is allowed to time out). 
* Cons: `set_timeout` need to be called in three different places because of the copy paste between `PicklingExecutor._internal_process_submissions` and `SlurmExecutor._internal_process_submissions` and also `_checkpoint` in the requeuing code.
  * Pros: the  `timeout_countdown`  logic is already duplicated, maybe we could introduce `prepare_submissions` method ?