### PR TITLE
Load numpy first if available

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
 show_error_codes=True
 
-[mypy-cloudpickle,ipdb,pytest,setuptools,numpy]
+[mypy-cloudpickle,ipdb,pytest,setuptools]
 ignore_missing_imports=True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
 show_error_codes=True
 
-[mypy-cloudpickle,ipdb,pytest,setuptools]
+[mypy-cloudpickle,ipdb,pytest,setuptools,numpy]
 ignore_missing_imports=True

--- a/submitit/core/submission.py
+++ b/submitit/core/submission.py
@@ -9,8 +9,10 @@ import time
 import traceback
 from pathlib import Path
 from typing import Union
-try:
-    import numpy  # pylint: disable=unused-import
+
+try:  # loading numpy before loading the pickle, to avoid unexpected interactions
+    # pylint: disable=unused-import
+    import numpy  # noqa
 except ImportError:
     pass
 

--- a/submitit/core/submission.py
+++ b/submitit/core/submission.py
@@ -9,6 +9,10 @@ import time
 import traceback
 from pathlib import Path
 from typing import Union
+try:
+    import numpy as np
+except ImportError:
+    pass
 
 from . import job_environment, utils
 from .logger import get_logger

--- a/submitit/core/submission.py
+++ b/submitit/core/submission.py
@@ -10,7 +10,7 @@ import traceback
 from pathlib import Path
 from typing import Union
 try:
-    import numpy as np
+    import numpy  # pylint: disable=unused-import
 except ImportError:
     pass
 

--- a/submitit/core/submission.py
+++ b/submitit/core/submission.py
@@ -12,7 +12,7 @@ from typing import Union
 
 try:  # loading numpy before loading the pickle, to avoid unexpected interactions
     # pylint: disable=unused-import
-    import numpy  # noqa
+    import numpy  # type: ignore  # noqa
 except ImportError:
     pass
 


### PR DESCRIPTION
Torch users often get the following issue:
```
Error: mkl-service + Intel(R) MKL: MKL_THREADING_LAYER=INTEL is incompatible with libgomp.so.1 library.
        Try to import numpy first or set the threading layer accordingly. Set MKL_SERVICE_FORCE_INTEL to force it.
srun: error: learnfair5096: task 0: Exited with exit code 1
srun: Terminating job step 26303611.0
```
This is due to numpy and torch being loaded in a different order when reloading the pickle. We need a way to make sure numpy is loaded first instead.