### PR TITLE
Fix links in pypi description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ def _replace_relative_links(regex: tp.Match[str]) -> str:
     link = regex.group("link")
     name = regex.group("name")
     if not link.startswith("http") and Path(link).exists():
-        githuburl = "github.com/facebookincubator/submitit/blob/{version}"
+        githuburl = f"github.com/facebookincubator/submitit/blob/{version}"
         string = f"[{name}](https://{githuburl}/{link})"
     return string
 

--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,8 @@ assert match is not None, "Could not find version in submitit/__init__.py"
 version = match.group("version")
 
 
-
 ## Description
+
 
 def _replace_relative_links(regex: tp.Match[str]) -> str:
     """Converts relative links into links to master
@@ -39,7 +39,7 @@ def _replace_relative_links(regex: tp.Match[str]) -> str:
     link = regex.group("link")
     name = regex.group("name")
     if not link.startswith("http") and Path(link).exists():
-        githuburl = "github.com/facebookincubator/submitit/blob/master"
+        githuburl = "github.com/facebookincubator/submitit/blob/{version}"
         string = f"[{name}](https://{githuburl}/{link})"
     return string
 

--- a/setup.py
+++ b/setup.py
@@ -7,13 +7,20 @@
 #
 
 import re
+import typing as tp
 from pathlib import Path
 
 from setuptools import find_packages, setup
 
+
+# Requirements
+
 requirements = {}
 for name in ["main", "dev"]:
     requirements[name] = Path(f"requirements/{name}.txt").read_text().splitlines()
+
+
+## Version
 
 init_str = Path("submitit/__init__.py").read_text()
 match = re.search(r"^__version__ = \"(?P<version>[\w\.]+?)\"$", init_str, re.MULTILINE)
@@ -21,13 +28,35 @@ assert match is not None, "Could not find version in submitit/__init__.py"
 version = match.group("version")
 
 
+
+## Description
+
+def _replace_relative_links(regex: tp.Match[str]) -> str:
+    """Converts relative links into links to master
+    """
+    string: str = regex.group()
+    link = regex.group("link")
+    name = regex.group("name")
+    if not link.startswith("http") and Path(link).exists():
+        githuburl = "github.com/facebookincubator/submitit/blob/master"
+        string = f"[{name}](https://{githuburl}/{link})"
+    return string
+
+
+pattern = re.compile(r"\[(?P<name>.+?)\]\((?P<link>\S+?)\)")
+long_description = Path("README.md").read_text(encoding="utf-8")
+long_description = re.sub(pattern, _replace_relative_links, long_description)
+
+
+## Setup
+
 setup(
     name="submitit",
     version=version,
     description="Python 3.6+ toolbox for submitting jobs to Slurm",
     author="Facebook AI Research",
     python_requires=">=3.6",
-    long_description=Path("README.md").read_text(encoding="utf-8"),
+    long_description=long_description,
     long_description_content_type="text/markdown",
     project_urls={
         "Source": "https://github.com/facebookincubator/submitit",

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ from pathlib import Path
 
 from setuptools import find_packages, setup
 
-
 # Requirements
 
 requirements = {}

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ version = match.group("version")
 
 def _replace_relative_links(regex: tp.Match[str]) -> str:
     """Converts relative links into links to master
+    so that links on Pypi long description are correct
     """
     string: str = regex.group()
     link = regex.group("link")


### PR DESCRIPTION
Links on pypi are broken because the README uses relative links:
https://pypi.org/project/submitit/

This converts relative links to the full url when creating setup.py long description