### PR TITLE
Ignore mem_gb=0 in autoexec

### DIFF
--- a/submitit/auto/test_auto.py
+++ b/submitit/auto/test_auto.py
@@ -98,3 +98,9 @@ def test_auto_batch_watcher() -> None:
         with executor.batch():
             job = executor.submit(print, "hi")
         assert not job.done()
+
+
+def test_slurm_executor(monkeypatch) -> None:
+    with test_slurm.mocked_slurm():
+        executor = auto.AutoExecutor(folder=".")
+    assert executor.cluster == "slurm"

--- a/submitit/auto/test_auto.py
+++ b/submitit/auto/test_auto.py
@@ -98,9 +98,3 @@ def test_auto_batch_watcher() -> None:
         with executor.batch():
             job = executor.submit(print, "hi")
         assert not job.done()
-
-
-def test_slurm_executor(monkeypatch) -> None:
-    with test_slurm.mocked_slurm():
-        executor = auto.AutoExecutor(folder=".")
-    assert executor.cluster == "slurm"

--- a/submitit/slurm/slurm.py
+++ b/submitit/slurm/slurm.py
@@ -152,7 +152,7 @@ def _parse_node_group(node_list: str, pos: int, parsed: List[str]) -> int:
             return pos + 1
         if c == "[":
             last_pos = node_list.index("]", pos)
-            suffixes = _expand_id_suffix(node_list[pos + 1: last_pos])
+            suffixes = _expand_id_suffix(node_list[pos + 1 : last_pos])
             prefixes = [prefix + suffix for prefix in prefixes for suffix in suffixes]
             pos = last_pos + 1
         else:
@@ -343,7 +343,7 @@ class SlurmExecutor(core.PicklingExecutor):
     @property
     def _submitit_command_str(self) -> str:
         return " ".join(
-            [shlex.quote(sys.executable), "-u -m submitit.core._submit", shlex.quote(str(self.folder)), ]
+            [shlex.quote(sys.executable), "-u -m submitit.core._submit", shlex.quote(str(self.folder)),]
         )
 
     def _make_submission_file_text(self, command: str, uid: str) -> str:
@@ -380,7 +380,7 @@ class SlurmExecutor(core.PicklingExecutor):
 def _get_default_parameters() -> Dict[str, Any]:
     """Parameters that can be set through update_parameters"""
     specs = inspect.getfullargspec(_make_sbatch_string)
-    zipped = zip(specs.args[-len(specs.defaults):], specs.defaults)  # type: ignore
+    zipped = zip(specs.args[-len(specs.defaults) :], specs.defaults)  # type: ignore
     return {key: val for key, val in zipped if key not in {"command", "folder", "map_count"}}
 
 

--- a/submitit/slurm/slurm.py
+++ b/submitit/slurm/slurm.py
@@ -152,7 +152,7 @@ def _parse_node_group(node_list: str, pos: int, parsed: List[str]) -> int:
             return pos + 1
         if c == "[":
             last_pos = node_list.index("]", pos)
-            suffixes = _expand_id_suffix(node_list[pos + 1 : last_pos])
+            suffixes = _expand_id_suffix(node_list[pos + 1: last_pos])
             prefixes = [prefix + suffix for prefix in prefixes for suffix in suffixes]
             pos = last_pos + 1
         else:
@@ -265,7 +265,9 @@ class SlurmExecutor(core.PicklingExecutor):
         params = super()._convert_parameters(params)
         # replace type in some cases
         if "mem" in params:
-            params["mem"] = f"{params['mem']}GB"
+            val = params.pop("mem")
+            if val:  # revert to default value if 0
+                params["mem"] = f"{val}GB"
         return params
 
     def _internal_update_parameters(self, **kwargs: Any) -> None:
@@ -341,7 +343,7 @@ class SlurmExecutor(core.PicklingExecutor):
     @property
     def _submitit_command_str(self) -> str:
         return " ".join(
-            [shlex.quote(sys.executable), "-u -m submitit.core._submit", shlex.quote(str(self.folder)),]
+            [shlex.quote(sys.executable), "-u -m submitit.core._submit", shlex.quote(str(self.folder)), ]
         )
 
     def _make_submission_file_text(self, command: str, uid: str) -> str:
@@ -378,7 +380,7 @@ class SlurmExecutor(core.PicklingExecutor):
 def _get_default_parameters() -> Dict[str, Any]:
     """Parameters that can be set through update_parameters"""
     specs = inspect.getfullargspec(_make_sbatch_string)
-    zipped = zip(specs.args[-len(specs.defaults) :], specs.defaults)  # type: ignore
+    zipped = zip(specs.args[-len(specs.defaults):], specs.defaults)  # type: ignore
     return {key: val for key, val in zipped if key not in {"command", "folder", "map_count"}}
 
 

--- a/submitit/slurm/test_slurm.py
+++ b/submitit/slurm/test_slurm.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+
 import submitit
 
 from .. import helpers

--- a/submitit/slurm/test_slurm.py
+++ b/submitit/slurm/test_slurm.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+import submitit
 
 from .. import helpers
 from ..core import job_environment, submission, test_core, utils
@@ -345,7 +346,7 @@ def test_name() -> None:
 
 
 @contextlib.contextmanager
-def with_slurm_job_nodelist(node_list: str):
+def with_slurm_job_nodelist(node_list: str) -> tp.Generator[slurm.SlurmJobEnvironment, None, None]:
     os.environ["SLURM_JOB_ID"] = "1"
     os.environ["SLURM_JOB_NODELIST"] = node_list
     yield slurm.SlurmJobEnvironment()
@@ -445,12 +446,23 @@ def test_slurm_weird_dir(weird_tmp_path: Path) -> None:
     for l in job.paths.submission_file.read_text().splitlines():
         if not l.startswith("#SBATCH"):
             continue
-        if not "=" in l:
+        if "=" not in l:
             continue
-        key, val = l[len("#SBATCH") :].strip().split("=", 1)
+        key, val = l[len("#SBATCH"):].strip().split("=", 1)
         sbatch_args[key] = val.replace("%j", job.job_id).replace("%t", "0")
 
     # We do not quote --output and --error values here,
     # because we want to check if they have been properly quoted before.
     subprocess.check_call("ls " + sbatch_args["--output"], shell=True)
     subprocess.check_call("ls " + sbatch_args["--error"], shell=True)
+
+
+@pytest.mark.parametrize("params", [{}, {"mem_gb": 0}])  # type: ignore
+def test_slurm_through_auto(params: tp.Dict[str, int], tmp_path: Path) -> None:
+    with mocked_slurm():
+        executor = submitit.AutoExecutor(folder=tmp_path)
+        executor.update_parameters(**params, slurm_additional_parameters={"mem_per_gpu": 12})
+        job = executor.submit(test_core.do_nothing, 1, 2, blublu=3)
+    text = job.paths.submission_file.read_text()
+    mem_lines = [x for x in text.splitlines() if "#SBATCH --mem" in x]
+    assert len(mem_lines) == 1, f"Unexpected lines: {mem_lines}"

--- a/submitit/slurm/test_slurm.py
+++ b/submitit/slurm/test_slurm.py
@@ -347,7 +347,7 @@ def test_name() -> None:
 
 
 @contextlib.contextmanager
-def with_slurm_job_nodelist(node_list: str) -> tp.Generator[slurm.SlurmJobEnvironment, None, None]:
+def with_slurm_job_nodelist(node_list: str) -> tp.Iterator[slurm.SlurmJobEnvironment]:
     os.environ["SLURM_JOB_ID"] = "1"
     os.environ["SLURM_JOB_NODELIST"] = node_list
     yield slurm.SlurmJobEnvironment()

--- a/submitit/slurm/test_slurm.py
+++ b/submitit/slurm/test_slurm.py
@@ -449,7 +449,7 @@ def test_slurm_weird_dir(weird_tmp_path: Path) -> None:
             continue
         if "=" not in l:
             continue
-        key, val = l[len("#SBATCH"):].strip().split("=", 1)
+        key, val = l[len("#SBATCH") :].strip().split("=", 1)
         sbatch_args[key] = val.replace("%j", job.job_id).replace("%t", "0")
 
     # We do not quote --output and --error values here,


### PR DESCRIPTION
Context: being able to **not** pass `mem` parameter so as to be able to use `mem-per-gpu` in the hydra plugin: https://github.com/facebookresearch/hydra/issues/1366
