### PR TITLE
Fixing deadlock when command prints a lot to stderr

### DIFF
--- a/submitit/core/test_utils.py
+++ b/submitit/core/test_utils.py
@@ -94,9 +94,7 @@ def test_command_function() -> None:
 
 
 def _test_command_function_deadlock():
-    f = utils.CommandFunction(["python3", "-c",
-                               "import sys;\n"
-                               "sys.stderr.write('a' * 100_000 + '\\n')"])
+    f = utils.CommandFunction(["python3", "-c", "import sys;\n" "sys.stderr.write('a' * 100_000 + '\\n')"])
     f()
 
 

--- a/submitit/core/test_utils.py
+++ b/submitit/core/test_utils.py
@@ -4,7 +4,6 @@
 # LICENSE file in the root directory of this source tree.
 #
 
-import multiprocessing
 import os
 import shutil
 import sys

--- a/submitit/core/test_utils.py
+++ b/submitit/core/test_utils.py
@@ -94,7 +94,7 @@ def test_command_function() -> None:
 
 
 def _test_command_function_deadlock():
-    f = utils.CommandFunction(["python3", "-c", "import sys;\n" "sys.stderr.write('a' * 100_000 + '\\n')"])
+    f = utils.CommandFunction(["python3", "-c", "import sys;\nsys.stderr.write('a' * 100_000 + '\\n')"])
     f()
 
 
@@ -105,6 +105,6 @@ def test_command_function_deadlock() -> None:
     proc.join(timeout)
     exitcode = proc.exitcode  # save exitcode before terminating
     if exitcode is None:
-        proc.kill()
+        proc.terminate()
     assert exitcode is not None, "command function deadlocked"
     assert exitcode == 0, "Deadlock test failed mysteriously"

--- a/submitit/core/utils.py
+++ b/submitit/core/utils.py
@@ -265,10 +265,13 @@ def copy_streams(in_streams: List[IO[bytes]], out_streams: List[_MultiStreamWrap
     assert len(in_streams) == len(out_streams)
 
     # We must use the raw buffer, as otherwise this could mess up our calls to select.
-    in_streams = [
-        stream.raw if isinstance(stream, io.BufferedIOBase) else stream
-        for stream in in_streams
-    ]
+    raw_streams: List[IO[bytes]] = []
+    for stream in in_streams:
+        if isinstance(stream, io.BufferedIOBase):
+            raw_streams.append(stream.raw)
+        else:
+            raw_streams.append(stream)
+    in_streams = raw_streams
 
     stream_map: Dict[int, Tuple[IO[bytes], _MultiStreamWrapper]] = {
         in_stream.fileno(): (in_stream, out_stream) for in_stream, out_stream in zip(in_streams, out_streams)

--- a/submitit/core/utils.py
+++ b/submitit/core/utils.py
@@ -350,11 +350,11 @@ class CommandFunction:
             out_streams = [stdout_stream, stderr_stream]
 
             try:
-                # We use select to read either from stderr or stdout.
-                # Failure to do so can result in a deadlock if the stderr
-                # or the stdout buffer get overflown.
-                # select is not the fastest, but it is the most supported.
-                copy_streams([process.stdout, process.stderr], out_streams)
+                # We use select to read either from stderr or stdout when data is available..
+                # Failure to do so can result in a deadlock if the stder or the stdout buffer get overflown.
+                # We must use the raw buffer, as otherwise this could mess up
+                # our calls to select.
+                copy_streams([process.stdout.raw, process.stderr.raw], out_streams)
             except Exception as e:
                 process.kill()
                 process.wait()


### PR DESCRIPTION
Currently, only stdout is read on the fly. If the stderr pipe fills up, then, the subprocess will deadlock when trying to write to stderr. As the parent process, only reads to stdout, and waits for the process to finish, this will never resolve. This uses instead the select function to find which file descriptor can be read from.

This also adds a unit test for this specific case.