### PR TITLE
add stderr_to_stdout option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,8 +49,8 @@ venv: venv/requirements.txt
 
 venv/requirements.txt: requirements/main.txt requirements/dev.txt
 	python3 -m venv venv
-	venv/bin/pip install --upgrade pip
-	venv/bin/pip install -U -e .[dev]
+	venv/bin/pip install --progress-bar off --upgrade pip
+	venv/bin/pip install --progress-bar off -U -e .[dev]
 	cat $^ > venv/requirements.txt
 
 installable: venv
@@ -73,6 +73,6 @@ release: integration
 	grep -e '__version__' ./submitit/__init__.py | sed 's/__version__ = //' | sed 's/"//g'
 	[[ ! -d dist ]] || rm -r dist
 	$(BIN)python setup.py sdist
-	$(BIN)pip install twine
+	$(BIN)pip install --progress-bar off twine
 	# Credentials are read from ~/.pypirc
 	$(BIN)python -m twine upload dist/*

--- a/submitit/auto/auto.py
+++ b/submitit/auto/auto.py
@@ -119,7 +119,16 @@ class AutoExecutor(Executor):
 
     @classmethod
     def _valid_parameters(cls) -> tp.Set[str]:
-        return {"name", "timeout_min", "mem_gb", "nodes", "cpus_per_task", "gpus_per_node", "tasks_per_node"}
+        return {
+            "name",
+            "timeout_min",
+            "mem_gb",
+            "nodes",
+            "cpus_per_task",
+            "gpus_per_node",
+            "tasks_per_node",
+            "stderr_to_stdout",
+        }
 
     def _internal_update_parameters(self, **kwargs: Any) -> None:
         """Updates submission parameters to srun/crun.

--- a/submitit/core/core.py
+++ b/submitit/core/core.py
@@ -54,8 +54,7 @@ class InfoWatcher:
 
     @property
     def num_calls(self) -> int:
-        """Number of calls to sacct
-        """
+        """Number of calls to sacct"""
         return self._num_calls
 
     def clear(self) -> None:
@@ -120,8 +119,7 @@ class InfoWatcher:
             self.update()
 
     def update(self) -> None:
-        """Updates the info of all registered jobs with a call to sacct
-        """
+        """Updates the info of all registered jobs with a call to sacct"""
         command = self._make_command()
         if command is None:
             return
@@ -142,8 +140,7 @@ class InfoWatcher:
                 self._finished.add(job_id)
 
     def register_job(self, job_id: str) -> None:
-        """Register a job on the instance for shared update
-        """
+        """Register a job on the instance for shared update"""
         assert isinstance(job_id, str)
         self._registered.add(job_id)
         self._start_time = _time.time()
@@ -196,15 +193,13 @@ class Job(tp.Generic[R]):
 
     @property
     def num_tasks(self) -> int:
-        """Returns the number of tasks in the Job
-        """
+        """Returns the number of tasks in the Job"""
         if not self._sub_jobs:
             return 1
         return len(self._sub_jobs)
 
     def submission(self) -> utils.DelayedSubmission:
-        """Returns the submitted object, with attributes `function`, `args` and `kwargs`
-        """
+        """Returns the submitted object, with attributes `function`, `args` and `kwargs`"""
         assert (
             self.paths.submitted_pickle.exists()
         ), f"Cannot find job submission pickle: {self.paths.submitted_pickle}"
@@ -364,12 +359,23 @@ class Job(tp.Generic[R]):
         while not self.paths.result_pickle.exists() and _time.time() - start_wait < timeout:
             _time.sleep(1)
         if not self.paths.result_pickle.exists():
+            message = [
+                f"Job {self.job_id} (task: {self.task_id}) with path {self.paths.result_pickle}",
+                f"has not produced any output (state: {self.state})",
+            ]
             log = self.stderr()
-            raise utils.UncompletedJobError(
-                f"Job {self.job_id} (task: {self.task_id}) with path {self.paths.result_pickle}\n"
-                f"has not produced any output (state: {self.state})\n"
-                f"Error stream produced:\n----------------------\n{log}"
-            )
+            if log:
+                message.extend(["Error stream produced:", "-" * 40, log])
+            elif self.paths.stdout.exists():
+                log = subprocess.check_output(["tail", "-40", str(self.paths.stdout)], encoding="utf-8")
+                message.extend([f"No error stream produced. Look at stdout: {self.paths.stdout}", "-" * 40])
+            else:
+                message.extend(
+                    [
+                        f"No error stream produced, nor output stream ! Stdout should be at: {self.paths.stdout}"
+                    ]
+                )
+            raise utils.UncompletedJobError("\n".join(message))
         try:
             output: tp.Tuple[str, tp.Any] = utils.pickle_load(self.paths.result_pickle)
         except EOFError:
@@ -431,13 +437,11 @@ class Job(tp.Generic[R]):
 
     @property
     def state(self) -> str:
-        """State of the job (forces an update)
-        """
+        """State of the job (forces an update)"""
         return self.watcher.get_state(self.job_id, mode="force")
 
     def get_info(self) -> tp.Dict[str, str]:
-        """Returns informations about the job as a dict (sacct call)
-        """
+        """Returns informations about the job as a dict (sacct call)"""
         return self.watcher.get_info(self.job_id, mode="force")
 
     def _get_logs_string(self, name: str) -> tp.Optional[str]:
@@ -500,8 +504,7 @@ class Job(tp.Generic[R]):
         return self.__dict__  # for pickling (see __setstate__)
 
     def __setstate__(self, state: tp.Dict[str, tp.Any]) -> None:
-        """Make sure jobs are registered when loaded from a pickle
-        """
+        """Make sure jobs are registered when loaded from a pickle"""
         self.__dict__.update(state)
         self._register_in_watcher()
 
@@ -674,8 +677,7 @@ class Executor(abc.ABC):
 
     @classmethod
     def _valid_parameters(cls) -> tp.Set[str]:
-        """Parameters that can be set through update_parameters
-        """
+        """Parameters that can be set through update_parameters"""
         return set()
 
     def _convert_parameters(self, params: tp.Dict[str, tp.Any]) -> tp.Dict[str, tp.Any]:
@@ -807,8 +809,7 @@ class PicklingExecutor(Executor):
 
     @abc.abstractmethod
     def _num_tasks(self) -> int:
-        """Returns the number of tasks associated to the job
-        """
+        """Returns the number of tasks associated to the job"""
         raise NotImplementedError
 
     @abc.abstractmethod
@@ -820,15 +821,13 @@ class PicklingExecutor(Executor):
 
     @abc.abstractmethod
     def _make_submission_command(self, submission_file_path: Path) -> tp.List[str]:
-        """Create the submission command.
-        """
+        """Create the submission command."""
         raise NotImplementedError
 
     @staticmethod
     @abc.abstractmethod
     def _get_job_id_from_submission_command(string: tp.Union[bytes, str]) -> str:
-        """Recover the job id from the output of the submission command.
-        """
+        """Recover the job id from the output of the submission command."""
         raise NotImplementedError
 
     @staticmethod

--- a/submitit/core/core.py
+++ b/submitit/core/core.py
@@ -368,13 +368,11 @@ class Job(tp.Generic[R]):
                 message.extend(["Error stream produced:", "-" * 40, log])
             elif self.paths.stdout.exists():
                 log = subprocess.check_output(["tail", "-40", str(self.paths.stdout)], encoding="utf-8")
-                message.extend([f"No error stream produced. Look at stdout: {self.paths.stdout}", "-" * 40])
-            else:
                 message.extend(
-                    [
-                        f"No error stream produced, nor output stream ! Stdout should be at: {self.paths.stdout}"
-                    ]
+                    [f"No error stream produced. Look at stdout: {self.paths.stdout}", "-" * 40, log]
                 )
+            else:
+                message.append(f"No output/error stream produced ! Check: {self.paths.stdout}")
             raise utils.UncompletedJobError("\n".join(message))
         try:
             output: tp.Tuple[str, tp.Any] = utils.pickle_load(self.paths.result_pickle)

--- a/submitit/core/test_core.py
+++ b/submitit/core/test_core.py
@@ -7,6 +7,7 @@
 # pylint: disable=redefined-outer-name
 import contextlib
 import pickle
+import subprocess
 import sys
 import time
 from pathlib import Path
@@ -44,14 +45,17 @@ class MockedSubprocess:
         self.job_id = job_id
         self._sacct = self.sacct(state, job_id, array)
         self._sbatch = f"Running job {job_id}\n".encode()
+        self._subprocess_check_output = subprocess.check_output
 
-    def __call__(self, command: str, **kwargs: Any) -> Any:
+    def __call__(self, command: List[str], **kwargs: Any) -> Any:
         if command[0] == "sacct":
             return self._sacct
         elif command[0] == "sbatch":
             return self._sbatch
         elif command[0] == "scancel":
             return ""
+        elif command[0] == "tail":
+            return self._subprocess_check_output(command, **kwargs)
         else:
             raise ValueError(f'Unknown command to mock "{command}".')
 

--- a/submitit/slurm/slurm.py
+++ b/submitit/slurm/slurm.py
@@ -449,6 +449,7 @@ def _make_sbatch_string(
         "additional_parameters",
         "setup",
         "signal_delay_s",
+        "stderr_to_stdout",
     ]
     parameters = {k: v for k, v in locals().items() if v and v is not None and k not in nonslurm}
     # rename and reformat parameters

--- a/submitit/slurm/slurm.py
+++ b/submitit/slurm/slurm.py
@@ -408,6 +408,7 @@ def _make_sbatch_string(
     exclusive: tp.Union[bool, str] = False,
     array_parallelism: int = 256,
     wckey: str = "submitit",
+    stderr_to_stdout: bool = False,
     map_count: tp.Optional[int] = None,  # used internally
     additional_parameters: tp.Optional[tp.Dict[str, tp.Any]] = None,
 ) -> str:
@@ -474,7 +475,8 @@ def _make_sbatch_string(
         stdout = stdout.replace("%j", "%A_%a")
         stderr = stderr.replace("%j", "%A_%a")
     parameters["output"] = stdout.replace("%t", "0")
-    parameters["error"] = stderr.replace("%t", "0")
+    if not stderr_to_stdout:
+        parameters["error"] = stderr.replace("%t", "0")
     parameters["open-mode"] = "append"
     if additional_parameters is not None:
         parameters.update(additional_parameters)
@@ -489,10 +491,11 @@ def _make_sbatch_string(
         lines += ["", "# setup"] + setup
     # commandline (this will run the function and args specified in the file provided as argument)
     # We pass --output and --error here, because the SBATCH command doesn't work as expected with a filename pattern
+    stderr_flag = "" if stderr_to_stdout else f"--error {stderr}"
     lines += [
         "",
         "# command",
         "export SUBMITIT_EXECUTOR=slurm",
-        f"srun --output {stdout} --error {stderr} --unbuffered {command}\n",
+        f"srun --output {stdout} {stderr_flag} --unbuffered {command}\n",
     ]
     return "\n".join(lines)

--- a/submitit/slurm/test_slurm.py
+++ b/submitit/slurm/test_slurm.py
@@ -261,6 +261,11 @@ def test_make_batch_string_gpu() -> None:
     assert "--gpus-per-node=2" in string
 
 
+def test_make_batch_stderr() -> None:
+    string = slurm._make_sbatch_string(command="blublu", folder="/tmp", stderr_to_stdout=True)
+    assert "--error" not in string
+
+
 def test_update_parameters_error() -> None:
     with mocked_slurm() as tmp:
         with pytest.raises(ValueError):


### PR DESCRIPTION
This implement the redirection stderr to stdout. This is actually the default behavior of `srun` (when you don't set the --error flag). 
Submitit was always setting --error and therefore always having stderr in a separate file.
This may be less convenient for people that prefer to look at the combined view.

stderr_to_stdout is now accessible from `update_parameters` like this:
https://github.com/facebookincubator/submitit/blob/55f482445dbadcc8a8295ac8226e9f407ae1bb1f/submitit/auto/test_auto.py#L105-L116

I also implemented the feature for the LocalExecutor for consistency.
The main issue is that we can't copy the full stderr on job crash to the raised Exception.
What I do now is that when stderr is empty the exception message will show the tail of the logs.