### PR TITLE
Trigger checkpointing on SIGTERM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ BIN=venv/bin/
 endif
 
 CODE=submitit
-CODE_AND_SETUP=$(CODE) setup.py docs/*.py
+CODE_AND_SETUP=$(CODE) setup.py docs/ integration/
 
 which:
 	which $(BIN)python

--- a/integration/preemption.py
+++ b/integration/preemption.py
@@ -1,0 +1,113 @@
+"""Preemption tests, need to be run on a an actual cluster"""
+import logging
+import shutil
+import subprocess
+import time
+from datetime import datetime
+from pathlib import Path
+
+import submitit
+from submitit import AutoExecutor, Job
+from submitit.core import test_core
+
+FILE = Path(__file__)
+LOGS = FILE.parent.parent / "log_test" / f"{FILE.stem}_log"
+
+log = logging.getLogger("preemption_main")
+formatter = logging.Formatter("%(name)s %(levelname)s (%(asctime)s) - %(message)s")
+handler = logging.StreamHandler()
+handler.setFormatter(formatter)
+log.setLevel(logging.INFO)
+log.addHandler(handler)
+
+
+def clock(partition: str, duration: int):
+    log = logging.getLogger(f"preemption_{partition}")
+    tick_tack = ["tick", "tack"]
+    try:
+        for minute in range(duration - 5):
+            log.info(tick_tack[minute % 2])
+            time.sleep(60)
+        logging.warning("*** Exited peacefully ***")
+        return duration
+    except:
+        logging.warning(f"!!! Interrupted on: {datetime.now().isoformat()}")
+        raise
+
+
+def pascal_job(partition: str, timeout_min: int, node: str = "") -> Job:
+    """Submit a job with specific constraint that we can preempt deterministically."""
+    ex = submitit.AutoExecutor(folder=LOGS, slurm_max_num_timeout=1)
+    ex.update_parameters(
+        name=f"submitit_preemption_{partition}",
+        timeout_min=timeout_min,
+        mem_gb=7,
+        slurm_constraint="pascal",
+        slurm_comment="submitit integration test",
+        slurm_partition=partition,
+        # pascal nodes have 80 cpus.
+        # By requesting 50 we now that their can be only one such job with this property.
+        cpus_per_task=50,
+        slurm_additional_parameters={},
+    )
+    if node:
+        ex.update_parameters(slurm_additional_parameters={"nodelist": node})
+
+    return ex.submit(clock, partition, timeout_min)
+
+
+def wait_job_is_running(job: Job) -> None:
+    while job.state != "RUNNING":
+        log.info(f"{job} is not RUNNING")
+        time.sleep(60)
+
+
+def sacct(job: Job, field: str):
+    sacct = subprocess.check_output(
+        ["sacct", "-j", job.job_id, "-o", f"JobID,{field}", "--parsable2"], text=True,
+    )
+    node = next((l.split("|")[-1] for l in sacct.splitlines() if l.startswith(job.job_id + "|")), None)
+    if node is None:
+        raise ValueError(f"Job not found {job.job_id}")
+    return node
+
+
+def main():
+    log.info("Hello !")
+    if LOGS.exists():
+        log.info(f"Cleaning up log folder: {LOGS}")
+        shutil.rmtree(str(LOGS))
+
+    job = pascal_job("learnfair", timeout_min=2 * 60)
+    log.info(f"Scheduled {job}, {job.paths.stdout}")
+    # log.info(job.paths.submission_file.read_text())
+
+    wait_job_is_running(job)
+    node = sacct(job, "NodeList")
+    log.info(f"{job} ({job.state}) is runnning on {node} !")
+    # Schedule another pascal job on the same node, whith high priority
+    priority_job = pascal_job("dev", timeout_min=15, node=node)
+    log.info(f"Schedule {priority_job} ({job.state}) on {node} with high priority.")
+    wait_job_is_running(priority_job)
+
+    # if priority_job is running, then job should have been preempted
+    learfair_stderr = job.stderr()
+    assert learfair_stderr is not None, job.paths.stderr
+
+    log.info(
+        f"Job {priority_job} ({priority_job.state}) started, "
+        f"job {job} ({job.state}) should have been preempted: {learfair_stderr}"
+    )
+    interruptions = [l for l in learfair_stderr.splitlines() if "Interrupted" in l]
+    assert len(interruptions) == 1, interruptions
+    assert job.state in ("PENDING"), job.state
+
+    interrupted_ts = interruptions[0].split("!!! Interrupted on: ")[-1]
+    interrupted = datetime.fromisoformat(interrupted_ts)
+
+    priority_job.result()
+    print("Preemption test succeeded ✅")
+
+
+if __name__ == "__main__":
+    main()

--- a/submitit/__init__.py
+++ b/submitit/__init__.py
@@ -17,4 +17,4 @@ from .local.local import LocalJob as LocalJob
 from .slurm.slurm import SlurmExecutor as SlurmExecutor
 from .slurm.slurm import SlurmJob as SlurmJob
 
-__version__ = "1.2.1"
+__version__ = "1.3.0"

--- a/submitit/core/job_environment.py
+++ b/submitit/core/job_environment.py
@@ -130,8 +130,7 @@ class JobEnvironment:
         @plugin-dev: Should be adapted to the signals used in this cluster.
         """
         handler = SignalHandler(self, paths, submission)
-        signal.signal(signal.SIGUSR1, handler.checkpoint_and_try_requeue)
-        signal.signal(signal.SIGTERM, handler.bypass)
+        signal.signal(signal.SIGTERM, handler.checkpoint_and_try_requeue)
 
     # pylint: disable=no-self-use,unused-argument
     def _requeue(self, countdown: int) -> None:

--- a/submitit/core/job_environment.py
+++ b/submitit/core/job_environment.py
@@ -131,6 +131,10 @@ class JobEnvironment:
         """
         handler = SignalHandler(self, paths, submission)
         signal.signal(signal.SIGTERM, handler.checkpoint_and_try_requeue)
+        # A priori we don't need other signals anymore,
+        # but still log them to make it easier to debug.
+        signal.signal(signal.SIGUSR1, handler.bypass)
+        signal.signal(signal.SIGCONT, handler.bypass)
 
     # pylint: disable=no-self-use,unused-argument
     def _requeue(self, countdown: int) -> None:

--- a/submitit/slurm/_sbatch_test_record.txt
+++ b/submitit/slurm/_sbatch_test_record.txt
@@ -10,7 +10,7 @@
 #SBATCH --open-mode=append
 #SBATCH --output=/tmp/%j_0_log.out
 #SBATCH --partition=learnfair
-#SBATCH --signal=USR1@90
+#SBATCH --signal=TERM@90
 #SBATCH --time=5
 #SBATCH --wckey=submitit
 

--- a/submitit/slurm/slurm.py
+++ b/submitit/slurm/slurm.py
@@ -47,7 +47,7 @@ class SlurmInfoWatcher(core.InfoWatcher):
         to_check = {x.split("_")[0] for x in self._registered - self._finished}
         if not to_check:
             return None
-        command = ["sacct", "-o", "JobID,State", "--parsable2"]
+        command = ["sacct", "-o", "JobID,State,NodeList", "--parsable2"]
         for jid in to_check:
             command.extend(["-j", str(jid)])
         return command

--- a/submitit/slurm/slurm.py
+++ b/submitit/slurm/slurm.py
@@ -447,11 +447,11 @@ def _make_sbatch_string(
         "array_parallelism",
         "additional_parameters",
         "setup",
+        "signal_delay_s",
     ]
-    parameters = {x: y for x, y in locals().items() if y and y is not None and x not in nonslurm}
+    parameters = {k: v for k, v in locals().items() if v and v is not None and k not in nonslurm}
     # rename and reformat parameters
-    parameters["signal"] = signal_delay_s
-    del parameters["signal_delay_s"]
+    parameters["signal"] = f"TERM@{signal_delay_s}"
     if job_name:
         parameters["job_name"] = utils.sanitize(job_name)
     if comment:
@@ -475,14 +475,14 @@ def _make_sbatch_string(
         stderr = stderr.replace("%j", "%A_%a")
     parameters["output"] = stdout.replace("%t", "0")
     parameters["error"] = stderr.replace("%t", "0")
-    parameters.update({"signal": f"USR1@{signal_delay_s}", "open-mode": "append"})
+    parameters["open-mode"] = "append"
     if additional_parameters is not None:
         parameters.update(additional_parameters)
     # now create
     lines = ["#!/bin/bash", "", "# Parameters"]
     lines += [
-        "#SBATCH --{}{}".format(x.replace("_", "-"), "" if parameters[x] is True else f"={parameters[x]}")
-        for x in sorted(parameters)
+        "#SBATCH --{}{}".format(k.replace("_", "-"), "" if parameters[k] is True else f"={parameters[k]}")
+        for k in sorted(parameters)
     ]
     # environment setup:
     if setup is not None:
@@ -493,6 +493,6 @@ def _make_sbatch_string(
         "",
         "# command",
         "export SUBMITIT_EXECUTOR=slurm",
-        f"srun --output {stdout} --error {stderr} --unbuffered {command}",
+        f"srun --output {stdout} --error {stderr} --unbuffered {command}\n",
     ]
     return "\n".join(lines)

--- a/submitit/slurm/test_slurm.py
+++ b/submitit/slurm/test_slurm.py
@@ -158,12 +158,9 @@ def test_requeuing_checkpointable(tmp_path: Path, fast_forward_clock) -> None:
     sig = get_signal_handler(job)
 
     fast_forward_clock(minutes=30)
-    with mock_requeue(not_called=True):
-        sig.bypass(signal.Signals.SIGTERM)
-
     # Preempt the job after 30 minutes, the job hasn't timeout.
     with pytest.raises(SystemExit), mock_requeue(called_with=1):
-        sig.checkpoint_and_try_requeue(signal.Signals.SIGUSR1)
+        sig.checkpoint_and_try_requeue(signal.Signals.SIGTERM)
 
     # Restart the job.
     sig = get_signal_handler(job)
@@ -174,7 +171,7 @@ def test_requeuing_checkpointable(tmp_path: Path, fast_forward_clock) -> None:
     # We are a little bit under the requested timedout, but close enough
     # to not consider this a preemption
     with pytest.raises(SystemExit), mock_requeue(called_with=0):
-        sig.checkpoint_and_try_requeue(signal.Signals.SIGUSR1)
+        sig.checkpoint_and_try_requeue(signal.Signals.SIGTERM)
 
     # Restart the job.
     sig = get_signal_handler(job)
@@ -184,7 +181,7 @@ def test_requeuing_checkpointable(tmp_path: Path, fast_forward_clock) -> None:
     with mock_requeue(not_called=True), pytest.raises(
         utils.UncompletedJobError, match="timed-out too many times."
     ):
-        sig.checkpoint_and_try_requeue(signal.Signals.SIGUSR1)
+        sig.checkpoint_and_try_requeue(signal.Signals.SIGTERM)
 
 
 def test_requeuing_not_checkpointable(tmp_path: Path, fast_forward_clock) -> None:
@@ -203,7 +200,7 @@ def test_requeuing_not_checkpointable(tmp_path: Path, fast_forward_clock) -> Non
 
     # Preempt the job after 30 minutes, the job hasn't timeout.
     with pytest.raises(SystemExit), mock_requeue(called_with=1):
-        sig.checkpoint_and_try_requeue(signal.Signals.SIGUSR1)
+        sig.checkpoint_and_try_requeue(signal.Signals.SIGTERM)
 
     # Restart the job from scratch
     sig = get_signal_handler(job)
@@ -213,7 +210,7 @@ def test_requeuing_not_checkpointable(tmp_path: Path, fast_forward_clock) -> Non
     with mock_requeue(not_called=True), pytest.raises(
         utils.UncompletedJobError, match="timed-out and not checkpointable"
     ):
-        sig.checkpoint_and_try_requeue(signal.Signals.SIGUSR1)
+        sig.checkpoint_and_try_requeue(signal.Signals.SIGTERM)
 
 
 def test_checkpoint_and_exit(tmp_path: Path) -> None:
@@ -224,7 +221,7 @@ def test_checkpoint_and_exit(tmp_path: Path) -> None:
 
     sig = get_signal_handler(job)
     with pytest.raises(SystemExit), mock_requeue(not_called=True):
-        sig.checkpoint_and_exit(signal.Signals.SIGUSR1)
+        sig.checkpoint_and_exit(signal.Signals.SIGTERM)
 
     # checkpoint_and_exit doesn't modify timeout counters.
     delayed = utils.DelayedSubmission.load(job.paths.submitted_pickle)


### PR DESCRIPTION
Since #1603 we don't use the chaining of SIGTERM / SIGUSR1 to detect between preemption and timeout.
Some Slurm cluster aren't configured with `preempt_send_user_signal` and don't receive the `SIGUSR1`, so we should checkpoint as soon as we receive SIGTERM.