### PR TITLE
Asyncio methods for job

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -137,11 +137,11 @@ executor.update_parameters(timeout_min=1, slurm_partition="dev")
 
 # await a single result
 job = executor.submit(slow_multiplication, 10, 2)
-await job.async_result()
+await job.async_job().result()
 
 # print results as they become available
 jobs = [executor.submit(slow_multiplication, k, random.randint(1, 4)) for k in range(1, 5)]
-for aws in asyncio.as_completed([j.async_result() for j in jobs]):
+for aws in asyncio.as_completed([j.async_job().result() for j in jobs]):
     result = await aws
     print(result)
 ```

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -118,6 +118,36 @@ with futures.ThreadPoolExecutor(max_workers=10) as executor:  # This is the only
     assert sum(job.done() for job in jobs) == 10  # all done
 ```
 
+## Asyncio
+
+You can also use the asyncio coroutines if you want
+
+```python
+import asyncio
+import random
+import submitit
+import time
+
+def slow_multiplication(x, y):
+    time.sleep(x*y)
+    return x*y
+
+executor = submitit.AutoExecutor(folder="log_test")
+executor.update_parameters(timeout_min=1, slurm_partition="dev")
+
+# await a single result
+job = executor.submit(slow_multiplication, 10, 2)
+await job.async_result()
+
+# print results as they become available
+jobs = [executor.submit(slow_multiplication, k, random.randint(1, 4)) for k in range(1, 5)]
+for aws in asyncio.as_completed([j.async_result() for j in jobs]):
+    result = await aws
+    print(result)
+```
+
+Note that you can also use `sumitit.helpers.as_completed` if you don't want to use coroutines
+
 ## Errors
 
 Errors are caught and their stacktrace is recorded. When calling `job.result()`, a `FailedJobError` is raised with the available information:

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -146,7 +146,7 @@ for aws in asyncio.as_completed([j.async_result() for j in jobs]):
     print(result)
 ```
 
-Note that you can also use `sumitit.helpers.as_completed` if you don't want to use coroutines
+Note that you can also use `submitit.helpers.as_completed` if you don't want to use coroutines
 
 ## Errors
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -137,11 +137,11 @@ executor.update_parameters(timeout_min=1, slurm_partition="dev")
 
 # await a single result
 job = executor.submit(slow_multiplication, 10, 2)
-await job.async_job().result()
+await job.awaitable().result()
 
 # print results as they become available
 jobs = [executor.submit(slow_multiplication, k, random.randint(1, 4)) for k in range(1, 5)]
-for aws in asyncio.as_completed([j.async_job().result() for j in jobs]):
+for aws in asyncio.as_completed([j.awaitable().result() for j in jobs]):
     result = await aws
     print(result)
 ```

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -3,6 +3,7 @@ isort==5.5.3
 mypy>=0.782
 pre-commit>=1.15.2
 pytest-cov>=2.6.1
+pytest-asyncio>=0.15.0
 coverage[toml]>=5.1
 pytest>=4.3.0
 pylint>=2.6.0

--- a/submitit/core/core.py
+++ b/submitit/core/core.py
@@ -291,54 +291,6 @@ class Job(tp.Generic[R]):
             raise job_exception  # pylint: disable=raising-bad-type
         return [result]
 
-    async def async_result(self, poll_interval: tp.Union[int, float] = 1) -> R:
-        """ asyncio version of the result() method.
-        Wait asynchornously for the result to be available by polling the self.done() method.
-        Parameters
-        ----------
-        poll_interval: int or float
-            how often to check if the result is available, in seconds
-        """
-        await self.async_wait(poll_interval)
-        return self.result()
-
-    async def async_results(self, poll_interval: tp.Union[int, float] = 1) -> tp.List[R]:
-        """ asyncio version of the results() method.
-
-        Waits asynchornously for ALL the results to be available by polling the self.done() method.
-
-        Parameters
-        ----------
-        poll_interval: int or float
-            how often to check if the result is available, in seconds
-        """
-        await self.async_wait(poll_interval)
-        # results are ready now
-        return self.results()
-
-    def results_as_compteled(self, poll_interval: tp.Union[int, float] = 1) -> tp.Iterator[asyncio.Future]:
-        """awaits for all tasks results concurrently. Note that the order of results is not guaranteed to match the order
-            of the tasks anymore as the earliest task coming back might not be the first one you sent.
-
-            Returns
-            -------
-            an iterable of Awaitables that can be awaited on to get the earliest result available of the remaining tasks.
-
-            Parameters
-            ----------
-            poll_interval: int or float
-                how often to check if the result is available, in seconds
-
-            (see https://docs.python.org/3/library/asyncio-task.html#asyncio.as_completed)
-        """
-        if self._sub_jobs:
-            yield from asyncio.as_completed(
-                [sub_job.async_result(poll_interval) for sub_job in self._sub_jobs]
-            )
-
-        # there is only one result anyway, let's just use async_result
-        yield asyncio.ensure_future(self.async_result())
-
     def exception(self) -> tp.Optional[tp.Union[utils.UncompletedJobError, utils.FailedJobError]]:
         """Waits for completion and returns (not raise) the
         exception containing the error log of the job
@@ -441,12 +393,6 @@ class Job(tp.Generic[R]):
         while not self.done():
             _time.sleep(1)
 
-    async def async_wait(self, poll_interval: tp.Union[int, float] = 1) -> None:
-        """ same as wait() but with asyncio sleep.
-        """
-        while not self.done():
-            await asyncio.sleep(poll_interval)
-
     def done(self, force_check: bool = False) -> bool:
         """Checks whether the job is finished.
         This is done by checking if the result file is present,
@@ -541,6 +487,12 @@ class Job(tp.Generic[R]):
             return "\n".join(stderr_not_none)
         return self._get_logs_string("stderr")
 
+    def async_job(self) -> "AsyncJobProxy[R]":
+        """Returns a proxy object that provides asyncio methods
+        for this Job.
+        """
+        return AsyncJobProxy(self)
+
     def __repr__(self) -> str:
         state = "UNKNOWN"
         try:
@@ -561,6 +513,92 @@ class Job(tp.Generic[R]):
         """Make sure jobs are registered when loaded from a pickle"""
         self.__dict__.update(state)
         self._register_in_watcher()
+
+
+class AsyncJobProxy(tp.Generic[R]):
+    def __init__(self, job: Job[R]):
+        self.job = job
+
+    async def wait(self, poll_interval: tp.Union[int, float] = 1) -> None:
+        """ same as wait() but with asyncio sleep.
+        """
+        while not self.job.done():
+            await asyncio.sleep(poll_interval)
+
+    async def result(self, poll_interval: tp.Union[int, float] = 1) -> R:
+        """ asyncio version of the result() method.
+        Wait asynchornously for the result to be available by polling the self.done() method.
+        Parameters
+        ----------
+        poll_interval: int or float
+            how often to check if the result is available, in seconds
+        """
+        await self.wait(poll_interval)
+        return self.job.result()
+
+    async def results(self, poll_interval: tp.Union[int, float] = 1) -> tp.List[R]:
+        """ asyncio version of the results() method.
+
+        Waits asynchornously for ALL the results to be available by polling the self.done() method.
+
+        Parameters
+        ----------
+        poll_interval: int or float
+            how often to check if the result is available, in seconds
+        """
+        await self.wait(poll_interval)
+        # results are ready now
+        return self.job.results()
+
+    def results_as_compteled(self, poll_interval: tp.Union[int, float] = 1) -> tp.Iterator[asyncio.Future]:
+        """awaits for all tasks results concurrently. Note that the order of results is not guaranteed to match the order
+            of the tasks anymore as the earliest task coming back might not be the first one you sent.
+
+            Returns
+            -------
+            an iterable of Awaitables that can be awaited on to get the earliest result available of the remaining tasks.
+
+            Parameters
+            ----------
+            poll_interval: int or float
+                how often to check if the result is available, in seconds
+
+            (see https://docs.python.org/3/library/asyncio-task.html#asyncio.as_completed)
+        """
+        if self.job.num_tasks > 1:
+            yield from asyncio.as_completed(
+                [self.job.task(i).async_job().result(poll_interval) for i in range(self.job.num_tasks)]
+            )
+
+        # there is only one result anyway, let's just use async result
+        yield asyncio.ensure_future(self.result())
+
+    ## proxy everything else so this just looks like a normal job
+    def __getattr__(self, item):
+        if hasattr(self.job, item):
+            return getattr(self.job, item)
+        raise AttributeError(item)
+
+    def __nonzero__(self):
+        return bool(self.job)
+
+    def __str__(self):
+        return str(self.job)
+
+    def __repr__(self):
+        return repr(self.job)
+
+    def __hash__(self):
+        return hash(self.job)
+
+    def __del__(self) -> None:
+        del self.job
+
+    def __getstate__(self) -> tp.Dict[str, tp.Any]:
+        return self.job.__getstate__()
+
+    def __setstate__(self, state: tp.Dict[str, tp.Any]) -> None:
+        return self.job.__setstate__(state)
 
 
 _MSG = (

--- a/submitit/core/core.py
+++ b/submitit/core/core.py
@@ -409,7 +409,7 @@ class Job(tp.Generic[R]):
 
         Note
         ----
-        This function is not full proof, and may say that the job is not terminated even
+        This function is not foolproof, and may say that the job is not terminated even
         if it is when the job failed (no result file, but job not running) because
         we avoid calling sacct/cinfo everytime done is called
         """

--- a/submitit/core/core.py
+++ b/submitit/core/core.py
@@ -573,33 +573,6 @@ class AsyncJobProxy(tp.Generic[R]):
         # there is only one result anyway, let's just use async result
         yield asyncio.ensure_future(self.result())
 
-    ## proxy everything else so this just looks like a normal job
-    def __getattr__(self, item):
-        if hasattr(self.job, item):
-            return getattr(self.job, item)
-        raise AttributeError(item)
-
-    def __nonzero__(self):
-        return bool(self.job)
-
-    def __str__(self):
-        return str(self.job)
-
-    def __repr__(self):
-        return repr(self.job)
-
-    def __hash__(self):
-        return hash(self.job)
-
-    def __del__(self) -> None:
-        del self.job
-
-    def __getstate__(self) -> tp.Dict[str, tp.Any]:
-        return self.job.__getstate__()
-
-    def __setstate__(self, state: tp.Dict[str, tp.Any]) -> None:
-        return self.job.__setstate__(state)
-
 
 _MSG = (
     "Interactions with jobs are not allowed within "

--- a/submitit/core/core.py
+++ b/submitit/core/core.py
@@ -487,7 +487,7 @@ class Job(tp.Generic[R]):
             return "\n".join(stderr_not_none)
         return self._get_logs_string("stderr")
 
-    def async_job(self) -> "AsyncJobProxy[R]":
+    def awaitable(self) -> "AsyncJobProxy[R]":
         """Returns a proxy object that provides asyncio methods
         for this Job.
         """
@@ -567,7 +567,7 @@ class AsyncJobProxy(tp.Generic[R]):
         """
         if self.job.num_tasks > 1:
             yield from asyncio.as_completed(
-                [self.job.task(i).async_job().result(poll_interval) for i in range(self.job.num_tasks)]
+                [self.job.task(i).awaitable().result(poll_interval) for i in range(self.job.num_tasks)]
             )
 
         # there is only one result anyway, let's just use async result

--- a/submitit/core/core.py
+++ b/submitit/core/core.py
@@ -147,6 +147,7 @@ class InfoWatcher:
         self._start_time = _time.time()
         self._last_status_check = float("-inf")
 
+
 # pylint: disable=too-many-public-methods
 class Job(tp.Generic[R]):
     """Access to a cluster job information and result.
@@ -315,9 +316,7 @@ class Job(tp.Generic[R]):
         # results are ready now
         return self.results()
 
-    def results_as_compteled(
-        self, poll_interval: tp.Union[int, float] = 1
-    ) -> tp.Iterator[asyncio.Future]:
+    def results_as_compteled(self, poll_interval: tp.Union[int, float] = 1) -> tp.Iterator[asyncio.Future]:
         """awaits for all tasks results concurrently. Note that the order of results is not guaranteed to match the order
             of the tasks anymore as the earliest task coming back might not be the first one you sent.
 

--- a/submitit/core/test_async.py
+++ b/submitit/core/test_async.py
@@ -33,3 +33,17 @@ async def test_results_single(tmp_path: Path):
         submission.process_job(folder=job.paths.folder)
     result = await result_task
     assert result == [24]
+
+
+@pytest.mark.asyncio
+async def test_results_ascompleted_single(tmp_path: Path):
+    executor = FakeExecutor(folder=tmp_path)
+    job = executor.submit(_three_time, 8)
+    with utils.environment_variables(_TEST_CLUSTER_="slurm", SLURM_JOB_ID=str(job.job_id)):
+        submission.process_job(folder=job.paths.folder)
+    count = 0
+    for aws in job.results_as_compteled():
+        result = await aws
+        count += 1
+        assert result == 24
+    assert count == 1

--- a/submitit/core/test_async.py
+++ b/submitit/core/test_async.py
@@ -16,7 +16,7 @@ from .test_core import FakeExecutor, _three_time
 async def test_result(tmp_path: Path, event_loop):
     executor = FakeExecutor(folder=tmp_path)
     job = executor.submit(_three_time, 8)
-    result_task = event_loop.create_task(job.async_result())
+    result_task = event_loop.create_task(job.async_job().result())
     with utils.environment_variables(_TEST_CLUSTER_="slurm", SLURM_JOB_ID=str(job.job_id)):
         submission.process_job(folder=job.paths.folder)
     result = await result_task
@@ -27,7 +27,7 @@ async def test_result(tmp_path: Path, event_loop):
 async def test_results_single(tmp_path: Path, event_loop):
     executor = FakeExecutor(folder=tmp_path)
     job = executor.submit(_three_time, 8)
-    result_task = event_loop.create_task(job.async_results())
+    result_task = event_loop.create_task(job.async_job().results())
     with utils.environment_variables(_TEST_CLUSTER_="slurm", SLURM_JOB_ID=str(job.job_id)):
         submission.process_job(folder=job.paths.folder)
     result = await result_task
@@ -41,7 +41,7 @@ async def test_results_ascompleted_single(tmp_path: Path):
     with utils.environment_variables(_TEST_CLUSTER_="slurm", SLURM_JOB_ID=str(job.job_id)):
         submission.process_job(folder=job.paths.folder)
     count = 0
-    for aws in job.results_as_compteled():
+    for aws in job.async_job().results_as_compteled():
         result = await aws
         count += 1
         assert result == 24

--- a/submitit/core/test_async.py
+++ b/submitit/core/test_async.py
@@ -4,12 +4,13 @@
 # LICENSE file in the root directory of this source tree.
 #
 
-import pytest
 import asyncio
 from pathlib import Path
 
+import pytest
+
+from . import submission, utils
 from .test_core import FakeExecutor, _three_time
-from . import core, submission, utils
 
 
 @pytest.mark.asyncio
@@ -21,6 +22,7 @@ async def test_result(tmp_path: Path):
         submission.process_job(folder=job.paths.folder)
     result = await result_task
     assert result == 24
+
 
 @pytest.mark.asyncio
 async def test_results_single(tmp_path: Path):

--- a/submitit/core/test_async.py
+++ b/submitit/core/test_async.py
@@ -1,0 +1,33 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+import pytest
+import asyncio
+from pathlib import Path
+
+from .test_core import FakeExecutor, _three_time
+from . import core, submission, utils
+
+
+@pytest.mark.asyncio
+async def test_result(tmp_path: Path):
+    executor = FakeExecutor(folder=tmp_path)
+    job = executor.submit(_three_time, 8)
+    result_task = asyncio.get_event_loop().create_task(job.async_result())
+    with utils.environment_variables(_TEST_CLUSTER_="slurm", SLURM_JOB_ID=str(job.job_id)):
+        submission.process_job(folder=job.paths.folder)
+    result = await result_task
+    assert result == 24
+
+@pytest.mark.asyncio
+async def test_results_single(tmp_path: Path):
+    executor = FakeExecutor(folder=tmp_path)
+    job = executor.submit(_three_time, 8)
+    result_task = asyncio.get_event_loop().create_task(job.async_results())
+    with utils.environment_variables(_TEST_CLUSTER_="slurm", SLURM_JOB_ID=str(job.job_id)):
+        submission.process_job(folder=job.paths.folder)
+    result = await result_task
+    assert result == [24]

--- a/submitit/core/test_async.py
+++ b/submitit/core/test_async.py
@@ -16,7 +16,7 @@ from .test_core import FakeExecutor, _three_time
 async def test_result(tmp_path: Path, event_loop):
     executor = FakeExecutor(folder=tmp_path)
     job = executor.submit(_three_time, 8)
-    result_task = event_loop.create_task(job.async_job().result())
+    result_task = event_loop.create_task(job.awaitable().result())
     with utils.environment_variables(_TEST_CLUSTER_="slurm", SLURM_JOB_ID=str(job.job_id)):
         submission.process_job(folder=job.paths.folder)
     result = await result_task
@@ -27,7 +27,7 @@ async def test_result(tmp_path: Path, event_loop):
 async def test_results_single(tmp_path: Path, event_loop):
     executor = FakeExecutor(folder=tmp_path)
     job = executor.submit(_three_time, 8)
-    result_task = event_loop.create_task(job.async_job().results())
+    result_task = event_loop.create_task(job.awaitable().results())
     with utils.environment_variables(_TEST_CLUSTER_="slurm", SLURM_JOB_ID=str(job.job_id)):
         submission.process_job(folder=job.paths.folder)
     result = await result_task
@@ -41,7 +41,7 @@ async def test_results_ascompleted_single(tmp_path: Path):
     with utils.environment_variables(_TEST_CLUSTER_="slurm", SLURM_JOB_ID=str(job.job_id)):
         submission.process_job(folder=job.paths.folder)
     count = 0
-    for aws in job.async_job().results_as_compteled():
+    for aws in job.awaitable().results_as_compteled():
         result = await aws
         count += 1
         assert result == 24

--- a/submitit/core/test_async.py
+++ b/submitit/core/test_async.py
@@ -14,10 +14,10 @@ from .test_core import FakeExecutor, _three_time
 
 
 @pytest.mark.asyncio
-async def test_result(tmp_path: Path):
+async def test_result(tmp_path: Path, event_loop):
     executor = FakeExecutor(folder=tmp_path)
     job = executor.submit(_three_time, 8)
-    result_task = asyncio.get_event_loop().create_task(job.async_result())
+    result_task = event_loop.create_task(job.async_result())
     with utils.environment_variables(_TEST_CLUSTER_="slurm", SLURM_JOB_ID=str(job.job_id)):
         submission.process_job(folder=job.paths.folder)
     result = await result_task
@@ -25,10 +25,10 @@ async def test_result(tmp_path: Path):
 
 
 @pytest.mark.asyncio
-async def test_results_single(tmp_path: Path):
+async def test_results_single(tmp_path: Path, event_loop):
     executor = FakeExecutor(folder=tmp_path)
     job = executor.submit(_three_time, 8)
-    result_task = asyncio.get_event_loop().create_task(job.async_results())
+    result_task = event_loop.create_task(job.async_results())
     with utils.environment_variables(_TEST_CLUSTER_="slurm", SLURM_JOB_ID=str(job.job_id)):
         submission.process_job(folder=job.paths.folder)
     result = await result_task

--- a/submitit/core/test_async.py
+++ b/submitit/core/test_async.py
@@ -4,7 +4,6 @@
 # LICENSE file in the root directory of this source tree.
 #
 
-import asyncio
 from pathlib import Path
 
 import pytest

--- a/submitit/core/utils.py
+++ b/submitit/core/utils.py
@@ -4,7 +4,6 @@
 # LICENSE file in the root directory of this source tree.
 #
 
-import asyncio
 import contextlib
 import io
 import itertools
@@ -22,12 +21,6 @@ from typing import IO, Any, Callable, Dict, Iterator, List, Optional, Tuple, Typ
 import cloudpickle
 
 R = TypeVar("R", covariant=True)
-
-
-def wrap_future(value) -> asyncio.Future:
-    f = asyncio.get_event_loop().create_future()
-    f.set_result(value)
-    return f
 
 
 @contextlib.contextmanager

--- a/submitit/core/utils.py
+++ b/submitit/core/utils.py
@@ -16,11 +16,9 @@ import subprocess
 import sys
 import tarfile
 from pathlib import Path
-from typing import IO, Any, Callable, Dict, Iterator, List, Optional, Tuple, Type, TypeVar, Union, cast
+from typing import IO, Any, Callable, Dict, Iterator, List, Optional, Tuple, Type, Union
 
 import cloudpickle
-
-R = TypeVar("R", covariant=True)
 
 
 @contextlib.contextmanager
@@ -359,7 +357,3 @@ class CommandFunction:
                 )
                 raise FailedJobError(stderr) from subprocess_error
         return stdout
-
-
-async def async_cast(v):
-    return cast(R, v)

--- a/submitit/core/utils.py
+++ b/submitit/core/utils.py
@@ -16,9 +16,11 @@ import subprocess
 import sys
 import tarfile
 from pathlib import Path
-from typing import IO, Any, Callable, Dict, Iterator, List, Optional, Tuple, Type, Union
+from typing import IO, Any, Callable, Dict, Iterator, List, Optional, Tuple, Type, Union, TypeVar, cast
 
 import cloudpickle
+
+R = TypeVar("R", covariant=True)
 
 
 @contextlib.contextmanager
@@ -357,3 +359,6 @@ class CommandFunction:
                 )
                 raise FailedJobError(stderr) from subprocess_error
         return stdout
+
+async def async_cast(v: Any, type: TypeVar) -> R: 
+    return cast(v, R)

--- a/submitit/core/utils.py
+++ b/submitit/core/utils.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 #
 
+import asyncio
 import contextlib
 import io
 import itertools
@@ -16,11 +17,17 @@ import subprocess
 import sys
 import tarfile
 from pathlib import Path
-from typing import IO, Any, Callable, Dict, Iterator, List, Optional, Tuple, Type, Union, TypeVar, cast
+from typing import IO, Any, Callable, Dict, Iterator, List, Optional, Tuple, Type, TypeVar, Union, cast
 
 import cloudpickle
 
 R = TypeVar("R", covariant=True)
+
+
+def wrap_future(value) -> asyncio.Future:
+    f = asyncio.get_event_loop().create_future()
+    f.set_result(value)
+    return f
 
 
 @contextlib.contextmanager
@@ -360,5 +367,6 @@ class CommandFunction:
                 raise FailedJobError(stderr) from subprocess_error
         return stdout
 
-async def async_cast(v: Any, type: TypeVar) -> R: 
-    return cast(v, R)
+
+async def async_cast(v):
+    return cast(R, v)

--- a/submitit/slurm/slurm.py
+++ b/submitit/slurm/slurm.py
@@ -427,7 +427,7 @@ def _make_sbatch_string(
     signal_delay_s: int
         delay between the kill signal and the actual kill of the slurm job.
     setup: list
-        a list of command to run in sbatch befure running srun
+        a list of command to run in sbatch before running srun
     map_size: int
         number of simultaneous map/array jobs allowed
     additional_parameters: dict


### PR DESCRIPTION
asyncio has a lot of prebuild tools for dealing with asynchronous execution (like submitit jobs). `gather` allows to deal with parts of the jobs failing, `as_completed` is available out of the box, timeouts can be added, and we can transparently combine jobs with other async stuff easily.

async also sounds cooler than blocking :D

I added tests for the single task job cases as I didn't see other tests for the multi task code. But it might be worth adding these too.