### PR TITLE
Add verbose_srun parameter for slurm

### DIFF
--- a/submitit/local/local.py
+++ b/submitit/local/local.py
@@ -206,6 +206,7 @@ def start_controller(
         SUBMITIT_EXECUTOR="local",
         CUDA_AVAILABLE_DEVICES=cuda_devices,
     )
+    # pylint: disable=consider-using-with
     process = subprocess.Popen(
         [sys.executable, "-m", "submitit.local._local", str(folder)], shell=False, env=env
     )

--- a/submitit/slurm/slurm.py
+++ b/submitit/slurm/slurm.py
@@ -411,6 +411,7 @@ def _make_sbatch_string(
     wckey: str = "submitit",
     stderr_to_stdout: bool = False,
     map_count: tp.Optional[int] = None,  # used internally
+    verbose_srun: bool = False,
     additional_parameters: tp.Optional[tp.Dict[str, tp.Any]] = None,
 ) -> str:
     """Creates the content of an sbatch file with provided parameters
@@ -434,6 +435,8 @@ def _make_sbatch_string(
         Forces any parameter to a given value in sbatch. This can be useful
         to add parameters which are not currently available in submitit.
         Eg: {"mail-user": "blublu@fb.com", "mail-type": "BEGIN"}
+    verbose_srun: bool
+        Uses -vv option on srun call
 
     Raises
     ------
@@ -451,6 +454,7 @@ def _make_sbatch_string(
         "setup",
         "signal_delay_s",
         "stderr_to_stdout",
+        "verbose_srun",
     ]
     parameters = {k: v for k, v in locals().items() if v and v is not None and k not in nonslurm}
     # rename and reformat parameters
@@ -494,10 +498,11 @@ def _make_sbatch_string(
     # commandline (this will run the function and args specified in the file provided as argument)
     # We pass --output and --error here, because the SBATCH command doesn't work as expected with a filename pattern
     stderr_flag = "" if stderr_to_stdout else f"--error {stderr}"
+    srun_command = "srun -vv" if verbose_srun else "srun"
     lines += [
         "",
         "# command",
         "export SUBMITIT_EXECUTOR=slurm",
-        f"srun --output {stdout} {stderr_flag} --unbuffered {command}\n",
+        f"{srun_command} --output {stdout} {stderr_flag} --unbuffered {command}\n",
     ]
     return "\n".join(lines)


### PR DESCRIPTION
It is sometimes useful to get the full verbose output from srun. This flag allows this possibility.