### PR TITLE
make all defaults None, only write parameter when its not None

### DIFF
--- a/submitit/slurm/slurm.py
+++ b/submitit/slurm/slurm.py
@@ -387,7 +387,7 @@ def _make_sbatch_string(
     command: str,
     folder: tp.Union[str, Path],
     job_name: str = "submitit",
-    partition: str = None,
+    partition: tp.Optional[str] = None,
     time: int = 5,
     nodes: int = 1,
     ntasks_per_node: int = 1,
@@ -402,11 +402,11 @@ def _make_sbatch_string(
     mem_per_gpu: tp.Optional[str] = None,
     mem_per_cpu: tp.Optional[str] = None,
     signal_delay_s: int = 90,
-    comment: str = "",
-    constraint: str = "",
-    exclude: str = "",
-    gres: str = "",
-    exclusive: tp.Union[bool, str] = False,
+    comment: tp.Optional[str] = None,
+    constraint: tp.Optional[str] = None,
+    exclude: tp.Optional[str] = None,
+    gres: tp.Optional[str] = None,
+    exclusive: tp.Optional[tp.Union[bool, str]] = None,
     array_parallelism: int = 256,
     wckey: str = "submitit",
     stderr_to_stdout: bool = False,
@@ -456,7 +456,7 @@ def _make_sbatch_string(
         "stderr_to_stdout",
         "verbose_srun",
     ]
-    parameters = {k: v for k, v in locals().items() if v and v is not None and k not in nonslurm}
+    parameters = {k: v for k, v in locals().items() if v is not None and k not in nonslurm}
     # rename and reformat parameters
     parameters["signal"] = f"USR1@{signal_delay_s}"
     if job_name:


### PR DESCRIPTION
It's useful to be able to schedule jobs with 0 gpus_per_node. However previous behaviour was to not write any parameters that evaled to False. This works fine when there is no property inheritance via slurm, but was a problem when scheduling a job with 0 gpu from a job with gpus.

This commit fixes this by enforcing defaults that are either None or eval to True. 
 