### PR TITLE
Add arbitrary slurm srun_args parameter

### DIFF
--- a/submitit/slurm/_sbatch_test_record.txt
+++ b/submitit/slurm/_sbatch_test_record.txt
@@ -15,4 +15,4 @@
 
 # command
 export SUBMITIT_EXECUTOR=slurm
-srun --output /tmp/%j_%t_log.out --error /tmp/%j_%t_log.err --unbuffered blublu
+srun -vv --cpu-bind none --output /tmp/%j_%t_log.out --error /tmp/%j_%t_log.err --unbuffered blublu

--- a/submitit/slurm/slurm.py
+++ b/submitit/slurm/slurm.py
@@ -412,7 +412,7 @@ def _make_sbatch_string(
     stderr_to_stdout: bool = False,
     map_count: tp.Optional[int] = None,  # used internally
     additional_parameters: tp.Optional[tp.Dict[str, tp.Any]] = None,
-    srun_args: tp.Optional[tp.Dict[str, tp.Any]] = None,
+    srun_args: tp.Optional[tp.Iterable[str]] = None,
 ) -> str:
     """Creates the content of an sbatch file with provided parameters
 
@@ -435,9 +435,8 @@ def _make_sbatch_string(
         Forces any parameter to a given value in sbatch. This can be useful
         to add parameters which are not currently available in submitit.
         Eg: {"mail-user": "blublu@fb.com", "mail-type": "BEGIN"}
-    srun_args: dict
-        Adds {key} {value} for non-None value and {key} where value is None
-        to the srun call.
+    srun_args: List[str]
+        Add each argument in the list to the srun call
 
     Raises
     ------
@@ -502,10 +501,7 @@ def _make_sbatch_string(
     if srun_args is None:
         srun_command = "srun"
     else:
-        extra_params = " ".join(
-            [f"{key} {value}" if value is not None else f"{key}" for key, value in srun_args.items()]
-        )
-        srun_command = f"srun {extra_params}"
+        srun_command = f"srun {' '.join(srun_args)}"
     lines += [
         "",
         "# command",

--- a/submitit/slurm/slurm.py
+++ b/submitit/slurm/slurm.py
@@ -411,8 +411,8 @@ def _make_sbatch_string(
     wckey: str = "submitit",
     stderr_to_stdout: bool = False,
     map_count: tp.Optional[int] = None,  # used internally
-    verbose_srun: bool = False,
     additional_parameters: tp.Optional[tp.Dict[str, tp.Any]] = None,
+    srun_args: tp.Optional[tp.Dict[str, tp.Any]] = None,
 ) -> str:
     """Creates the content of an sbatch file with provided parameters
 
@@ -435,8 +435,9 @@ def _make_sbatch_string(
         Forces any parameter to a given value in sbatch. This can be useful
         to add parameters which are not currently available in submitit.
         Eg: {"mail-user": "blublu@fb.com", "mail-type": "BEGIN"}
-    verbose_srun: bool
-        Uses -vv option on srun call
+    srun_args: dict
+        Adds {key} {value} for non-None value and {key} where value is None
+        to the srun call.
 
     Raises
     ------
@@ -454,7 +455,7 @@ def _make_sbatch_string(
         "setup",
         "signal_delay_s",
         "stderr_to_stdout",
-        "verbose_srun",
+        "srun_args",
     ]
     parameters = {k: v for k, v in locals().items() if v is not None and k not in nonslurm}
     # rename and reformat parameters
@@ -498,7 +499,13 @@ def _make_sbatch_string(
     # commandline (this will run the function and args specified in the file provided as argument)
     # We pass --output and --error here, because the SBATCH command doesn't work as expected with a filename pattern
     stderr_flag = "" if stderr_to_stdout else f"--error {stderr}"
-    srun_command = "srun -vv" if verbose_srun else "srun"
+    if srun_args is None:
+        srun_command = "srun"
+    else:
+        extra_params = " ".join(
+            [f"{key} {value}" if value is not None else f"{key}" for key, value in srun_args.items()]
+        )
+        srun_command = f"srun {extra_params}"
     lines += [
         "",
         "# command",

--- a/submitit/slurm/test_slurm.py
+++ b/submitit/slurm/test_slurm.py
@@ -241,6 +241,7 @@ def test_make_sbatch_string() -> None:
         partition="learnfair",
         exclusive=True,
         additional_parameters=dict(blublu=12),
+        srun_args={"-vv": None, "--cpu-bind": "none"},
     )
     assert "partition" in string
     assert "--command" not in string

--- a/submitit/slurm/test_slurm.py
+++ b/submitit/slurm/test_slurm.py
@@ -241,7 +241,7 @@ def test_make_sbatch_string() -> None:
         partition="learnfair",
         exclusive=True,
         additional_parameters=dict(blublu=12),
-        srun_args={"-vv": None, "--cpu-bind": "none"},
+        srun_args=["-vv", "--cpu-bind none"],
     )
     assert "partition" in string
     assert "--command" not in string


### PR DESCRIPTION
srun comes with a few parameters that cannot be customized via SBATCH (verbosity levels, cpu-bind)
This PR removes verbose_srun parameter, and replaces it with srun_args.

Updated `test_slurm` and `_sbatch_test_record.txt` to reflect the changes.