### PR TITLE
Add job paths to JobEnvironment

### DIFF
--- a/submitit/core/job_environment.py
+++ b/submitit/core/job_environment.py
@@ -49,6 +49,9 @@ class JobEnvironment:
 
     @property
     def paths(self) -> JobPaths:
+        """Provides the paths used by submitit, including
+        stdout, stderr, submitted_pickle and folder.
+        """
         folder = os.environ["SUBMITIT_FOLDER"]
         return JobPaths(folder, job_id=self.job_id, task_id=self.global_rank)
 

--- a/submitit/core/job_environment.py
+++ b/submitit/core/job_environment.py
@@ -47,6 +47,11 @@ class JobEnvironment:
             n = n[: -len("JobEnvironment")]
         return n.lower()
 
+    @property
+    def paths(self) -> JobPaths:
+        folder = os.environ["SUBMITIT_FOLDER"]
+        return JobPaths(folder, job_id=self.job_id, task_id=self.global_rank)
+
     def activated(self) -> bool:
         """Tests if we are running inside this environment.
 

--- a/submitit/core/submission.py
+++ b/submitit/core/submission.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 #
 
+import os
 import argparse
 import time
 import traceback
@@ -32,9 +33,9 @@ def process_job(folder: Union[Path, str]) -> None:
     -----------
     Creates a picked output file next to the job file.
     """
-    folder = Path(folder)
+    os.environ["SUBMITIT_FOLDER"] = str(folder)
     env = job_environment.JobEnvironment()
-    paths = utils.JobPaths(folder, job_id=env.job_id, task_id=env.global_rank)
+    paths = env.paths
     logger = get_logger()
     logger.info(f"Starting with {env}")
     logger.info(f"Loading pickle: {paths.submitted_pickle}")

--- a/submitit/core/submission.py
+++ b/submitit/core/submission.py
@@ -4,8 +4,8 @@
 # LICENSE file in the root directory of this source tree.
 #
 
-import os
 import argparse
+import os
 import time
 import traceback
 from pathlib import Path


### PR DESCRIPTION
Providing access to the folder from inside the job is helpful for users if they want to store other information along submitit logs