### PR TITLE
Add MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements/*.txt


### PR DESCRIPTION
Add `MANIFEST.in` to include `requirements/*.txt` in the source distribution.

This is needed because the requirements files are missing from `submitit-1.4.0.tar.gz` on pypi and this source package cannot be installed.