### PR TITLE
bug fix: pandas slicing key error

### DIFF
--- a/docs/mnist.py
+++ b/docs/mnist.py
@@ -45,6 +45,7 @@ class MnistTrainer(submitit.helpers.Checkpointable):
             log(f"*** Entering stage '{self.stage}' ***")
             # Load data from https://www.openml.org/d/554
             X, y = fetch_openml("mnist_784", version=1, return_X_y=True)
+            X, y = X.numpy(), y.numpy()
 
             random_state = check_random_state(0)
             permutation = random_state.permutation(X.shape[0])


### PR DESCRIPTION
In the previous implementation, slicing `X` and `y` with `permutation` results in a key error like
```
*** KeyError: "None of [Int64Index([10840, 56267, 14849, 62726, 47180, 61640, 52730, 21847, 20394,\n            45806,\n            ...\n            52620, 39512, 48600, 55026, 41993, 21243, 45891, 42613, 43567,\n            68268],\n           dtype='int64', length=70000)] are in the [columns]"
```
so I converted the pandas dataframe into numpy arrays instead.