### PR TITLE
Fixed typo in map_array() docstring and contribution guide

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -11,7 +11,7 @@ but we don't have any major feature planned ahead.
 ## Pull Requests
 We actively welcome your pull requests.
 
-1. Fork the repo and create your branch from `master`.
+1. Fork the repo and create your branch from `main`.
 2. Create a virtual environment and activate it: `make venv && . venv/bin/activate`
 3. If you've added code please add tests.
 4. If you've changed APIs, please update the documentation.

--- a/submitit/core/core.py
+++ b/submitit/core/core.py
@@ -691,7 +691,7 @@ class Executor(abc.ABC):
         -------
         a = [1, 2, 3]
         b = [10, 20, 30]
-        executor.submit(add, a, b)
+        executor.map_array(add, a, b)
         # jobs will compute 1 + 10, 2 + 20, 3 + 30
         """
         submissions = [utils.DelayedSubmission(fn, *args) for args in zip(*iterable)]


### PR DESCRIPTION
The doctring for `map_array()` incorrectly had a call to `executor.submit(add, a, b)` instead of `executor.map_array(add, a, b)`. Also, going through the Contribution guidelines I noticed that the PR steps refer to the old 'master' branch instead of the new 'main' branch.