### PR TITLE
Fix DebugExecutor

### DIFF
--- a/submitit/__init__.py
+++ b/submitit/__init__.py
@@ -18,4 +18,4 @@ from .local.local import LocalJob as LocalJob
 from .slurm.slurm import SlurmExecutor as SlurmExecutor
 from .slurm.slurm import SlurmJob as SlurmJob
 
-__version__ = "1.4.1"
+__version__ = "1.4.2"

--- a/submitit/__init__.py
+++ b/submitit/__init__.py
@@ -18,4 +18,4 @@ from .local.local import LocalJob as LocalJob
 from .slurm.slurm import SlurmExecutor as SlurmExecutor
 from .slurm.slurm import SlurmJob as SlurmJob
 
-__version__ = "1.4.0"
+__version__ = "1.4.1"

--- a/submitit/local/debug.py
+++ b/submitit/local/debug.py
@@ -77,6 +77,7 @@ class DebugJob(Job[R]):
         os.environ.update(self.environ)
 
         root_logger = logging.getLogger("")
+        self.paths.stdout.parent.mkdir(exist_ok=True, parents=True)
         stdout_handler = logging.FileHandler(self.paths.stdout)
         stdout_handler.setLevel(logging.DEBUG)
         stderr_handler = logging.FileHandler(self.paths.stderr)
@@ -137,6 +138,10 @@ class DebugJob(Job[R]):
 
     def get_info(self, mode: str = "force") -> Dict[str, str]:  # pylint: disable=unused-argument
         return {"STATE": self.state}
+
+    def __del__(self) -> None:
+        # Skip parent code
+        return
 
 
 class DebugExecutor(Executor):


### PR DESCRIPTION
The DebugExecutor isn't explicitly creating the output folder which can create issues in some cases.

Also the default job __del__ will try to cancel the job in some cases which we don't want to do for the DebugJob.