### PR TITLE
Add %a and %A options in slurm directory names

### DIFF
--- a/submitit/core/utils.py
+++ b/submitit/core/utils.py
@@ -83,7 +83,13 @@ class JobPaths:
         """Replace id tag by actual id if available"""
         if self.job_id is None:
             return Path(path)
-        return Path(str(path).replace("%j", str(self.job_id)).replace("%t", str(self.task_id)))
+        replaced_path = str(path).replace("%j", str(self.job_id)).replace("%t", str(self.task_id))
+        array_id, *array_index = str(self.job_id).split("_", 1)
+        if "%a" in replaced_path:
+            if len(array_index) != 1:
+                raise ValueError("%a is in the folder path but this is not a job array")
+            replaced_path = replaced_path.replace("%a", array_index[0])
+        return Path(replaced_path.replace("%A", array_id))
 
     def move_temporary_file(self, tmp_path: Union[Path, str], name: str) -> None:
         self.folder.mkdir(parents=True, exist_ok=True)
@@ -93,7 +99,8 @@ class JobPaths:
     def get_first_id_independent_folder(folder: Union[Path, str]) -> Path:
         """Returns the closest folder which is id independent"""
         parts = Path(folder).expanduser().absolute().parts
-        indep_parts = itertools.takewhile(lambda x: not any(tag in x for tag in ["%j", "%t"]), parts)
+        tags = ["%j", "%t", "%A", "%a"]
+        indep_parts = itertools.takewhile(lambda x: not any(tag in x for tag in tags), parts)
         return Path(*indep_parts)
 
     def __repr__(self) -> str:


### PR DESCRIPTION
Add %a and %A options in slurm directory names to allow more possibilities

+ avoid existing bugs when these strings are in the folder names, because for nom it creates an inconsistency between slurm and what submitit does internally