### PR TITLE
Intermediate submission

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ installable: installable_local installable_wheel
 installable_local: venv
 	(. ./venv/bin/activate ; cd /tmp ; python -c "import submitit")
 
-BUILD=dev$(CIRCLE_BUILD_NUM)
+BUILD=dev0$(CIRCLE_BUILD_NUM)
 USER_VENV=/tmp/submitit_user_venv/
 CURRENT_VERSION=`grep -e '__version__' ./submitit/__init__.py | sed 's/__version__ = //' | sed 's/"//g'`
 TEST_PYPI=--index-url 'https://test.pypi.org/simple/' --no-cache-dir --no-deps --progress-bar off

--- a/submitit/core/core.py
+++ b/submitit/core/core.py
@@ -627,7 +627,7 @@ class Executor(abc.ABC):
         self.parameters = {} if parameters is None else parameters
         # storage for the batch context manager, for batch submissions:
         self._delayed_batch: tp.Optional[tp.List[tp.Tuple[Job[tp.Any], utils.DelayedSubmission]]] = None
-        self._allow_intermediate_submissions = False
+        self._allow_implicit_submissions = False
 
     @classmethod
     def name(cls) -> str:
@@ -637,13 +637,13 @@ class Executor(abc.ABC):
         return n.lower()
 
     @contextlib.contextmanager
-    def batch(self, allow_intermediate_submissions: bool = False) -> tp.Iterator[None]:
+    def batch(self, allow_implicit_submissions: bool = False) -> tp.Iterator[None]:
         """Creates a context within which all submissions are packed into a job array.
         By default the array submissions happens when leaving the context
 
         Parameter
         ---------
-        allow_intermediate_submissions: bool
+        allow_implicit_submissions: bool
             submits the current batch whenever a job attribute is accessed instead of raising an exception
 
         Example
@@ -659,7 +659,7 @@ class Executor(abc.ABC):
             if trying to access a job instance attribute while the batch is not exited, and
             intermediate submissions are not allowed.
         """
-        self._allow_intermediate_submissions = allow_intermediate_submissions
+        self._allow_implicit_submissions = allow_implicit_submissions
         if self._delayed_batch is not None:
             raise RuntimeError('Nesting "with executor.batch()" contexts is not allowed.')
         self._delayed_batch = []
@@ -682,7 +682,7 @@ class Executor(abc.ABC):
     def _submit_delayed_batch(self) -> None:
         assert self._delayed_batch is not None
         if not self._delayed_batch:
-            if not self._allow_intermediate_submissions:
+            if not self._allow_implicit_submissions:
                 warnings.warn(
                     'No submission happened during "with executor.batch()" context.', category=RuntimeWarning
                 )
@@ -700,7 +700,7 @@ class Executor(abc.ABC):
             # ugly hack for AutoExecutor class which is known at runtime
             cls = self.job_class if self.job_class is not Job else self._executor.job_class  # type: ignore
             job: Job[R] = cls.__new__(cls)  # empty shell
-            if self._allow_intermediate_submissions:
+            if self._allow_implicit_submissions:
                 job.__dict__[_BATCH_HOOK_] = self._submit_delayed_batch
             self._delayed_batch.append((job, ds))
         else:

--- a/submitit/core/core.py
+++ b/submitit/core/core.py
@@ -559,6 +559,7 @@ class DelayedJob(Job[R]):
         # fill in the empty shell, the pickle way
         self.__dict__.pop("_submitit_executor", None)
         self.__dict__.update(new_job.__dict__)
+        # pylint: disable=attribute-defined-outside-init
         self.__class__ = new_job.__class__  # type: ignore
 
     def __repr__(self) -> str:

--- a/submitit/core/test_async.py
+++ b/submitit/core/test_async.py
@@ -41,7 +41,7 @@ async def test_results_ascompleted_single(tmp_path: Path):
     with utils.environment_variables(_TEST_CLUSTER_="slurm", SLURM_JOB_ID=str(job.job_id)):
         submission.process_job(folder=job.paths.folder)
     count = 0
-    for aws in job.awaitable().results_as_compteled():
+    for aws in job.awaitable().results_as_completed():
         result = await aws
         count += 1
         assert result == 24

--- a/submitit/core/test_core.py
+++ b/submitit/core/test_core.py
@@ -200,9 +200,11 @@ def test_fake_executor_batch(tmp_path: Path) -> None:
     executor = FakeExecutor(folder=tmp_path)
     with executor.batch():
         job = executor.submit(_three_time, 8)
+        assert isinstance(job, core.DelayedJob)
     assert isinstance(job, FakeJob)
-    with executor.batch():  #  make sure we can send a new batch
+    with executor.batch():  # make sure we can send a new batch
         job = executor.submit(_three_time, 8)
+        assert isinstance(job, core.DelayedJob)
     assert isinstance(job, FakeJob)
     # bad update
     with pytest.raises(RuntimeError):
@@ -212,11 +214,17 @@ def test_fake_executor_batch(tmp_path: Path) -> None:
     with pytest.raises(AttributeError):
         with executor.batch():
             job = executor.submit(_three_time, 8)
+            assert isinstance(job, core.DelayedJob)
             job.job_id  # pylint: disable=pointless-statement
+        assert isinstance(job, core.DelayedJob)
+
     with executor.batch(allow_implicit_submissions=True):
         job = executor.submit(_three_time, 8)
+        assert isinstance(job, core.DelayedJob)
         job.job_id  # pylint: disable=pointless-statement
+        assert isinstance(job, FakeJob)
         assert not executor._delayed_batch
+
     # empty context
     with pytest.warns(RuntimeWarning):
         with executor.batch():
@@ -226,6 +234,8 @@ def test_fake_executor_batch(tmp_path: Path) -> None:
         with executor.batch():
             with executor.batch():
                 job = executor.submit(_three_time, 8)
+                assert isinstance(job, core.DelayedJob)
+            assert isinstance(job, FakeJob)
 
 
 def test_unpickling_watcher_registration(tmp_path: Path) -> None:

--- a/submitit/core/test_core.py
+++ b/submitit/core/test_core.py
@@ -200,6 +200,7 @@ def test_fake_executor_batch(tmp_path: Path) -> None:
     executor = FakeExecutor(folder=tmp_path)
     with executor.batch():
         job = executor.submit(_three_time, 8)
+    assert isinstance(job, FakeJob)
     with executor.batch():  #  make sure we can send a new batch
         job = executor.submit(_three_time, 8)
     assert isinstance(job, FakeJob)

--- a/submitit/core/test_core.py
+++ b/submitit/core/test_core.py
@@ -212,7 +212,7 @@ def test_fake_executor_batch(tmp_path: Path) -> None:
         with executor.batch():
             job = executor.submit(_three_time, 8)
             job.job_id  # pylint: disable=pointless-statement
-    with executor.batch(allow_intermediate_submissions=True):
+    with executor.batch(allow_implicit_submissions=True):
         job = executor.submit(_three_time, 8)
         job.job_id  # pylint: disable=pointless-statement
         assert not executor._delayed_batch

--- a/submitit/core/test_core.py
+++ b/submitit/core/test_core.py
@@ -212,6 +212,10 @@ def test_fake_executor_batch(tmp_path: Path) -> None:
         with executor.batch():
             job = executor.submit(_three_time, 8)
             job.job_id  # pylint: disable=pointless-statement
+    with executor.batch(allow_intermediate_submissions=True):
+        job = executor.submit(_three_time, 8)
+        job.job_id  # pylint: disable=pointless-statement
+        assert not executor._delayed_batch
     # empty context
     with pytest.warns(RuntimeWarning):
         with executor.batch():

--- a/submitit/core/utils.py
+++ b/submitit/core/utils.py
@@ -16,7 +16,6 @@ import subprocess
 import sys
 import tarfile
 from pathlib import Path
-import typing as tp
 from typing import IO, Any, Callable, Dict, Iterator, List, Optional, Tuple, Type, Union
 
 import cloudpickle

--- a/submitit/core/utils.py
+++ b/submitit/core/utils.py
@@ -16,6 +16,7 @@ import subprocess
 import sys
 import tarfile
 from pathlib import Path
+import typing as tp
 from typing import IO, Any, Callable, Dict, Iterator, List, Optional, Tuple, Type, Union
 
 import cloudpickle


### PR DESCRIPTION
This is my own take on #1653 
It keeps the same API,  but I like this implementation better.

Now calling `submit` from a `ex.batch()` context will return a `DelayedJob` which only has a pointer to the executor.
This also has the benefit of catching the `AttributeError` more explicitly.

@jrapin what do you think ?