### PR TITLE
Escape all sbatch arguments

### DIFF
--- a/submitit/core/test_utils.py
+++ b/submitit/core/test_utils.py
@@ -66,14 +66,6 @@ def test_slurmpaths_id_independent() -> None:
     assert output.name == "truc"
 
 
-def test_sanitize() -> None:
-    assert utils.sanitize("AlreadySanitized") == "AlreadySanitized"
-    assert utils.sanitize("Name with space") == "Name_with_space"
-    assert utils.sanitize("Name with space", only_alphanum=False) == '"Name with space"'
-    assert utils.sanitize("Name with    many    spaces") == "Name_with_many_spaces"
-    assert utils.sanitize(" Non alph@^ Nüm%") == "_Non_alph_Nüm_"
-
-
 def test_archive_dev_folders(tmp_path: Path) -> None:
     utils.archive_dev_folders([Path(__file__).parent], outfile=tmp_path.with_suffix(".tar.gz"))
     shutil.unpack_archive(str(tmp_path.with_suffix(".tar.gz")), extract_dir=tmp_path)

--- a/submitit/core/utils.py
+++ b/submitit/core/utils.py
@@ -9,7 +9,6 @@ import io
 import itertools
 import os
 import pickle
-import re
 import select
 import shutil
 import subprocess
@@ -216,18 +215,6 @@ def copy_par_file(par_file: Union[str, Path], folder: Union[str, Path]) -> Path:
     dst_name = folder / par_file.name
     shutil.copy2(par_file, dst_name)
     return dst_name
-
-
-def sanitize(s: str, only_alphanum: bool = True, in_quotes: bool = True) -> str:
-    """Sanitize the string"""
-    if only_alphanum:
-        # Replace all consecutive non-alphanum character by _
-        return re.sub(r"[\W_]+", "_", s)
-    if in_quotes:
-        # Escape double quotes in the original string and put it between double quotes
-        s = s.replace('"', '\\"')
-        s = f'"{s}"'
-    return s
 
 
 def pickle_load(filename: Union[str, Path]) -> Any:

--- a/submitit/core/utils.py
+++ b/submitit/core/utils.py
@@ -60,6 +60,9 @@ class JobPaths:
 
     @property
     def submission_file(self) -> Path:
+        if self.job_id and "_" in self.job_id:
+            # We only have one submission file per job array
+            return self._format_id(self.folder / "%A_submission.sh")
         return self._format_id(self.folder / "%j_submission.sh")
 
     @property

--- a/submitit/slurm/_sbatch_test_record.txt
+++ b/submitit/slurm/_sbatch_test_record.txt
@@ -15,4 +15,4 @@
 
 # command
 export SUBMITIT_EXECUTOR=slurm
-srun --unbuffered --output /tmp/%j_%t_log.out --error /tmp/%j_%t_log.err -vv --cpu-bind none blublu
+srun --unbuffered --output /tmp/%j_%t_log.out --error /tmp/%j_%t_log.err -vv --cpu-bind none blublu bar

--- a/submitit/slurm/_sbatch_test_record.txt
+++ b/submitit/slurm/_sbatch_test_record.txt
@@ -15,4 +15,4 @@
 
 # command
 export SUBMITIT_EXECUTOR=slurm
-srun -vv --cpu-bind none --output /tmp/%j_%t_log.out --error /tmp/%j_%t_log.err --unbuffered blublu
+srun --unbuffered --output /tmp/%j_%t_log.out --error /tmp/%j_%t_log.err -vv --cpu-bind none blublu

--- a/submitit/slurm/slurm.py
+++ b/submitit/slurm/slurm.py
@@ -495,11 +495,14 @@ def _make_sbatch_string(
     stderr_flags = [] if stderr_to_stdout else ["--error", stderr]
     if srun_args is None:
         srun_args = []
+
+    srun_cmd = _shlex_join(["srun", "--unbuffered", "--output", stdout, *stderr_flags, *srun_args])
     lines += [
         "",
         "# command",
         "export SUBMITIT_EXECUTOR=slurm",
-        _shlex_join(["srun", "--unbuffered", "--output", stdout, *stderr_flags, *srun_args, command]),
+        # The input "command" is supposed to be a valid shell command
+        " ".join((srun_cmd, command)),
         "",
     ]
     return "\n".join(lines)

--- a/submitit/slurm/slurm.py
+++ b/submitit/slurm/slurm.py
@@ -460,10 +460,6 @@ def _make_sbatch_string(
     parameters = {k: v for k, v in locals().items() if v is not None and k not in nonslurm}
     # rename and reformat parameters
     parameters["signal"] = f"USR1@{signal_delay_s}"
-    if job_name:
-        parameters["job_name"] = utils.sanitize(job_name)
-    if comment:
-        parameters["comment"] = utils.sanitize(comment, only_alphanum=False)
     if num_gpus is not None:
         warnings.warn(
             '"num_gpus" is deprecated, please use "gpus_per_node" instead (overwritting with num_gpus)'
@@ -473,8 +469,8 @@ def _make_sbatch_string(
         warnings.warn('"cpus_per_gpu" requires to set "gpus_per_task" to work (and not "gpus_per_node")')
     # add necessary parameters
     paths = utils.JobPaths(folder=folder)
-    stdout = shlex.quote(str(paths.stdout))
-    stderr = shlex.quote(str(paths.stderr))
+    stdout = str(paths.stdout)
+    stderr = str(paths.stderr)
     # Job arrays will write files in the form  <ARRAY_ID>_<ARRAY_TASK_ID>_<TASK_ID>
     if map_count is not None:
         assert isinstance(map_count, int) and map_count
@@ -489,26 +485,22 @@ def _make_sbatch_string(
         parameters.update(additional_parameters)
     # now create
     lines = ["#!/bin/bash", "", "# Parameters"]
-    # pylint: disable=consider-using-f-string
-    lines += [
-        "#SBATCH --{}{}".format(k.replace("_", "-"), "" if parameters[k] is True else f"={parameters[k]}")
-        for k in sorted(parameters)
-    ]
+    for k in sorted(parameters):
+        lines.append(_as_sbatch_flag(k, parameters[k]))
     # environment setup:
     if setup is not None:
         lines += ["", "# setup"] + setup
     # commandline (this will run the function and args specified in the file provided as argument)
     # We pass --output and --error here, because the SBATCH command doesn't work as expected with a filename pattern
-    stderr_flag = "" if stderr_to_stdout else f"--error {stderr}"
+    stderr_flags = [] if stderr_to_stdout else ["--error", stderr]
     if srun_args is None:
-        srun_command = "srun"
-    else:
-        srun_command = f"srun {' '.join(srun_args)}"
+        srun_args = []
     lines += [
         "",
         "# command",
         "export SUBMITIT_EXECUTOR=slurm",
-        f"{srun_command} --output {stdout} {stderr_flag} --unbuffered {command}\n",
+        shlex.join(["srun", "--unbuffered", "--output", stdout, *stderr_flags, *srun_args, command]),
+        "",
     ]
     return "\n".join(lines)
 
@@ -517,3 +509,12 @@ def _convert_mem(mem_gb: float) -> str:
     if mem_gb == int(mem_gb):
         return f"{int(mem_gb)}GB"
     return f"{int(mem_gb * 1024)}MB"
+
+
+def _as_sbatch_flag(key: str, value: tp.Any) -> str:
+    key = key.replace("_", "-")
+    if value is True:
+        return f"#SBATCH --{key}"
+
+    value = shlex.quote(str(value))
+    return f"#SBATCH --{key}={value}"

--- a/submitit/slurm/slurm.py
+++ b/submitit/slurm/slurm.py
@@ -499,7 +499,7 @@ def _make_sbatch_string(
         "",
         "# command",
         "export SUBMITIT_EXECUTOR=slurm",
-        shlex.join(["srun", "--unbuffered", "--output", stdout, *stderr_flags, *srun_args, command]),
+        _shlex_join(["srun", "--unbuffered", "--output", stdout, *stderr_flags, *srun_args, command]),
         "",
     ]
     return "\n".join(lines)
@@ -518,3 +518,8 @@ def _as_sbatch_flag(key: str, value: tp.Any) -> str:
 
     value = shlex.quote(str(value))
     return f"#SBATCH --{key}={value}"
+
+
+def _shlex_join(split_command: tp.List[str]) -> str:
+    """Same as shlex.join, but that was only added in Python 3.8"""
+    return " ".join(shlex.quote(arg) for arg in split_command)

--- a/submitit/slurm/test_slurm.py
+++ b/submitit/slurm/test_slurm.py
@@ -241,7 +241,7 @@ def test_make_sbatch_string() -> None:
         partition="learnfair",
         exclusive=True,
         additional_parameters=dict(blublu=12),
-        srun_args=["-vv", "--cpu-bind none"],
+        srun_args=["-vv", "--cpu-bind", "none"],
     )
     assert "partition" in string
     assert "--command" not in string

--- a/submitit/slurm/test_slurm.py
+++ b/submitit/slurm/test_slurm.py
@@ -236,7 +236,7 @@ def test_checkpoint_and_exit(tmp_path: Path) -> None:
 
 def test_make_sbatch_string() -> None:
     string = slurm._make_sbatch_string(
-        command="blublu",
+        command="blublu bar",
         folder="/tmp",
         partition="learnfair",
         exclusive=True,


### PR DESCRIPTION
This should fix #1658

IIUC the reason we were sanitizing was to allow to make a sbatch script with the job name inside.
With escaping we don't need sanitizing anymore.

This should also resolve some un reported problem with all other sbatch arguments that accept strings.