### PR TITLE
make a git tag on `make release`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,11 +100,16 @@ integration: clean_cache venv check_format lint installable test_coverage
 	# Use `make -k integration` to run all checks even if previous fails.
 
 release: integration
-	grep -e '__version__' ./submitit/__init__.py | sed 's/__version__ = //' | sed 's/"//g'
+	echo "Releasing submitit $(CURRENT_VERSION)"
 	[ ! -d dist ] || rm -r dist
+	# Make sure the repo is in a clean state
 	git diff --exit-code
 	$(BIN)python submitit/test_documentation.py
 	# --setup-py generates a setup.py file to allow user with old
 	# versions of pip to install it without flit.
-	$(BIN)python -m flit publish --setup-py
+	git tag $(CURRENT_VERSION)
+	# To have a reproducible build we use the timestamp of the last commit:
+	# https://flit.pypa.io/en/latest/reproducible.html
+	SOURCE_DATE_EPOCH=`git log -n1 --format=%cd --date=unix` $(BIN)python -m flit publish --setup-py
 	git checkout HEAD -- README.md
+	git push origin $(CURRENT_VERSION)

--- a/submitit/__init__.py
+++ b/submitit/__init__.py
@@ -18,4 +18,4 @@ from .local.local import LocalJob as LocalJob
 from .slurm.slurm import SlurmExecutor as SlurmExecutor
 from .slurm.slurm import SlurmJob as SlurmJob
 
-__version__ = "1.4.2"
+__version__ = "1.4.3"


### PR DESCRIPTION
Automatically push tags, this should avoid issues like  #1690 where I forgot to push the 1.4.2 tag.

Also enable reproducible builds. 
The main trick is to set the timestamp of the files to the timestamp of the last commit, instead of using the filesystem date.
https://flit.pypa.io/en/latest/reproducible.html

This way someone else building the project on another machine should get the same wheel bit-by-bit.