### PR TITLE
Fix truncation of "Executor" in executor class name

### DIFF
--- a/submitit/core/core.py
+++ b/submitit/core/core.py
@@ -669,7 +669,7 @@ class Executor(abc.ABC):
     def name(cls) -> str:
         n = cls.__name__
         if n.endswith("Executor"):
-            n = n[:-len("Executor")]
+            n = n[: -len("Executor")]
         return n.lower()
 
     @contextlib.contextmanager

--- a/submitit/core/core.py
+++ b/submitit/core/core.py
@@ -669,7 +669,7 @@ class Executor(abc.ABC):
     def name(cls) -> str:
         n = cls.__name__
         if n.endswith("Executor"):
-            n = n.rstrip("Executor")
+            n = n[:-len("Executor")]
         return n.lower()
 
     @contextlib.contextmanager


### PR DESCRIPTION
Noticed this while trying to make my own plugin/Executor... `rstrip` can remove too much!