### PR TITLE
[NCCL Conflict] Use USR2 instead of USR1

### DIFF
--- a/submitit/core/job_environment.py
+++ b/submitit/core/job_environment.py
@@ -27,6 +27,7 @@ class JobEnvironment:
     Override _env to map environment variable to each property.
     """
 
+    USR_SIG = "USR2"
     _env: ClassVar[Dict[str, str]] = {}
 
     def __new__(cls, *args: Any) -> "JobEnvironment":
@@ -127,6 +128,10 @@ class JobEnvironment:
         info_str = ", ".join(info)
         return f"JobEnvironment({info_str})"
 
+    @staticmethod
+    def _usr_sig() -> Any:
+        return {"USR1": signal.SIGUSR1, "USR2": signal.SIGUSR2}[self.USR_SIG]
+
     def _handle_signals(self, paths: JobPaths, submission: DelayedSubmission) -> None:
         """Set up signals handler for the current executable.
 
@@ -134,7 +139,7 @@ class JobEnvironment:
         @plugin-dev: Should be adapted to the signals used in this cluster.
         """
         handler = SignalHandler(self, paths, submission)
-        signal.signal(signal.SIGUSR1, handler.checkpoint_and_try_requeue)
+        signal.signal(self._usr_sig(), handler.checkpoint_and_try_requeue)
         # A priori we don't need other signals anymore,
         # but still log them to make it easier to debug.
         signal.signal(signal.SIGTERM, handler.bypass)

--- a/submitit/core/job_environment.py
+++ b/submitit/core/job_environment.py
@@ -128,9 +128,9 @@ class JobEnvironment:
         info_str = ", ".join(info)
         return f"JobEnvironment({info_str})"
 
-    @staticmethod
-    def _usr_sig() -> Any:
-        return {"USR1": signal.SIGUSR1, "USR2": signal.SIGUSR2}[self.USR_SIG]
+    @classmethod
+    def _usr_sig(cls) -> Any:
+        return {"USR1": signal.SIGUSR1, "USR2": signal.SIGUSR2}[cls.USR_SIG]
 
     def _handle_signals(self, paths: JobPaths, submission: DelayedSubmission) -> None:
         """Set up signals handler for the current executable.

--- a/submitit/core/job_environment.py
+++ b/submitit/core/job_environment.py
@@ -27,7 +27,10 @@ class JobEnvironment:
     Override _env to map environment variable to each property.
     """
 
-    USR_SIG = "USR2"
+    # preemption signal uses USR2 as default, but this behavior
+    # can be overiden
+    # CAUTION: NCCL may catch USR1 so it should be avoided
+    USR_SIG = os.environ.get("SUBMITIT_PREEMPT_SIGNAL", "USR2")
     _env: ClassVar[Dict[str, str]] = {}
 
     def __new__(cls, *args: Any) -> "JobEnvironment":

--- a/submitit/core/job_environment.py
+++ b/submitit/core/job_environment.py
@@ -138,7 +138,9 @@ class JobEnvironment:
         name = "SIG" + cls.USR_SIG
         out = getattr(signal, name, None)
         if out is None:
-            raise RuntimeError(f"Unknown signal {name}, you may need to unset or update env var {_PREEMPT_SIG_ENV} (Eg: USR2)")
+            raise RuntimeError(
+                f"Unknown signal {name}, you may need to unset or update env var {_PREEMPT_SIG_ENV} (Eg: USR2)"
+            )
         return out
 
     def _handle_signals(self, paths: JobPaths, submission: DelayedSubmission) -> None:

--- a/submitit/local/local.py
+++ b/submitit/local/local.py
@@ -71,7 +71,7 @@ class LocalJob(core.Job[R]):
     def _interrupt(self) -> None:
         """Sends preemption / timeout signal to the job (for testing purpose)"""
         assert self._process is not None
-        self._process.send_signal(signal.SIGUSR1)
+        self._process.send_signal(LocalJobEnvironment._usr_sig())
 
     def __del__(self) -> None:
         if self._cancel_at_deletion:
@@ -135,7 +135,7 @@ class LocalExecutor(core.PicklingExecutor):
         - visible_gpus (Sequence[int])
         - tasks_per_node (int)
         - nodes (int). Must be 1 if specified
-        - signal_delay_s (int): USR1 signal delay before timeout
+        - signal_delay_s (int): USRX (lately: USR2) signal delay before timeout
 
         Other parameters are ignored
         """
@@ -314,7 +314,7 @@ class Controller:
                 return exit_codes
 
             if step == almost_timeout:
-                self._forward_signal(signal.SIGUSR1)
+                self._forward_signal(LocalJobEnvironment._usr_sig())
 
             time.sleep(1.0 / freq)
         return [t.poll() for t in self.tasks]

--- a/submitit/slurm/_sbatch_test_record.txt
+++ b/submitit/slurm/_sbatch_test_record.txt
@@ -9,7 +9,7 @@
 #SBATCH --open-mode=append
 #SBATCH --output=/tmp/%j_0_log.out
 #SBATCH --partition=learnfair
-#SBATCH --signal=USR1@90
+#SBATCH --signal=USR2@90
 #SBATCH --time=5
 #SBATCH --wckey=submitit
 

--- a/submitit/slurm/slurm.py
+++ b/submitit/slurm/slurm.py
@@ -6,7 +6,6 @@
 
 import functools
 import inspect
-import signal
 import os
 import re
 import shlex
@@ -153,7 +152,7 @@ def _parse_node_group(node_list: str, pos: int, parsed: List[str]) -> int:
             return pos + 1
         if c == "[":
             last_pos = node_list.index("]", pos)
-            suffixes = _expand_id_suffix(node_list[pos + 1: last_pos])
+            suffixes = _expand_id_suffix(node_list[pos + 1 : last_pos])
             prefixes = [prefix + suffix for prefix in prefixes for suffix in suffixes]
             pos = last_pos + 1
         else:
@@ -379,7 +378,7 @@ class SlurmExecutor(core.PicklingExecutor):
 def _get_default_parameters() -> Dict[str, Any]:
     """Parameters that can be set through update_parameters"""
     specs = inspect.getfullargspec(_make_sbatch_string)
-    zipped = zip(specs.args[-len(specs.defaults):], specs.defaults)  # type: ignore
+    zipped = zip(specs.args[-len(specs.defaults) :], specs.defaults)  # type: ignore
     return {key: val for key, val in zipped if key not in {"command", "folder", "map_count"}}
 
 

--- a/submitit/slurm/test_slurm.py
+++ b/submitit/slurm/test_slurm.py
@@ -6,7 +6,6 @@
 import contextlib
 import signal
 import os
-import signal
 import subprocess
 import typing as tp
 from pathlib import Path
@@ -477,7 +476,7 @@ def test_slurm_weird_dir(weird_tmp_path: Path) -> None:
             continue
         if "=" not in l:
             continue
-        key, val = l[len("#SBATCH"):].strip().split("=", 1)
+        key, val = l[len("#SBATCH") :].strip().split("=", 1)
         sbatch_args[key] = val.replace("%j", job.job_id).replace("%t", "0")
 
     # We do not quote --output and --error values here,

--- a/submitit/slurm/test_slurm.py
+++ b/submitit/slurm/test_slurm.py
@@ -4,8 +4,8 @@
 # LICENSE file in the root directory of this source tree.
 #
 import contextlib
-import signal
 import os
+import signal
 import subprocess
 import typing as tp
 from pathlib import Path


### PR DESCRIPTION
We cannot rely on USR1 for requeing because NCCL catches it...
https://github.com/NVIDIA/nccl/blob/7aa1c46fd551d5514474cfc55848219dc67ca683/src/proxy.cc#L601