### PR TITLE
Use SIGHUP as default for preemption signal

### DIFF
--- a/submitit/core/job_environment.py
+++ b/submitit/core/job_environment.py
@@ -29,10 +29,10 @@ class JobEnvironment:
     Override _env to map environment variable to each property.
     """
 
-    # preemption signal uses USR2 as default, but this behavior
-    # can be overiden
+    # preemption signal uses HUP as default, but this behavior
+    # can be overiden (eg: export SUBMITIT_PREEMPT_SIGNAL=USR2)
     # CAUTION: NCCL may catch USR1 so it should be avoided
-    USR_SIG = os.environ.get(_PREEMPT_SIG_ENV, "USR2")
+    USR_SIG = os.environ.get(_PREEMPT_SIG_ENV, "HUP")
     _env: ClassVar[Dict[str, str]] = {}
 
     def __new__(cls, *args: Any) -> "JobEnvironment":

--- a/submitit/local/local.py
+++ b/submitit/local/local.py
@@ -135,7 +135,7 @@ class LocalExecutor(core.PicklingExecutor):
         - visible_gpus (Sequence[int])
         - tasks_per_node (int)
         - nodes (int). Must be 1 if specified
-        - signal_delay_s (int): USRX (lately: USR2) signal delay before timeout
+        - signal_delay_s (int): signal (lately: HUP) delay before timeout
 
         Other parameters are ignored
         """

--- a/submitit/slurm/_sbatch_test_record.txt
+++ b/submitit/slurm/_sbatch_test_record.txt
@@ -9,7 +9,7 @@
 #SBATCH --open-mode=append
 #SBATCH --output=/tmp/%j_0_log.out
 #SBATCH --partition=learnfair
-#SBATCH --signal=USR2@90
+#SBATCH --signal=HUP@90
 #SBATCH --time=5
 #SBATCH --wckey=submitit
 


### PR DESCRIPTION
As mentioned in #1697, a very unlikely signal may be safer (SIGHUP is usually used with a shell).
This seems to work on slurm:

```
submitit INFO (2022-07-12 04:17:53,762) - Starting with JobEnvironment(job_id=60601445, hostname=learnfair0293, local_rank=0(2), node=0(1), global_rank=0(2))
submitit INFO (2022-07-12 04:17:53,762) - Loading pickle: /private/home/jrapin/fairinternal/multixp/outputs/test_xp/60601445_submitted.pkl
Setting up distributed environement with MASTER_ADDR=learnfair0293, MASTER_PORT=33666, RANK=0, WORLD_SIZE=2
submitit WARNING (2022-07-12 04:18:45,706) - Bypassing signal SIGTERM
submitit INFO (2022-07-12 04:18:45,881) - Job has not timed out. Ran 1 minutes out of requested 20 minutes.
submitit WARNING (2022-07-12 04:18:45,881) - Caught signal SIGHUP on learnfair0293: this job is preempted.
submitit INFO (2022-07-12 04:18:45,912) - Requeued job 60601445 (3 remaining timeouts)
submitit WARNING (2022-07-12 04:18:45,912) - Bypassing signal SIGCONT
submitit INFO (2022-07-12 04:18:45,913) - Exiting gracefully after preemption/timeout.
submitit INFO (2022-07-12 04:21:41,214) - Starting with JobEnvironment(job_id=60601445, hostname=learnfair0293, local_rank=0(2), node=0(1), global_rank=0(2)
....
```