### PR TITLE
Add support for OAR Scheduler

### DIFF
--- a/submitit/__init__.py
+++ b/submitit/__init__.py
@@ -17,5 +17,7 @@ from .local.local import LocalExecutor as LocalExecutor
 from .local.local import LocalJob as LocalJob
 from .slurm.slurm import SlurmExecutor as SlurmExecutor
 from .slurm.slurm import SlurmJob as SlurmJob
+from .oar.oar import OarExecutor as OarExecutor
+from .oar.oar import OarJob as OarJob
 
 __version__ = "1.4.6"

--- a/submitit/core/plugins.py
+++ b/submitit/core/plugins.py
@@ -25,11 +25,12 @@ def _get_plugins() -> Tuple[List[Type["Executor"]], List["JobEnvironment"]]:
 
     from ..local import debug, local
     from ..slurm import slurm
+    from ..oar import oar
 
     # TODO: use sys.modules.keys() and importlib.resources to find the files
     # We load both kind of entry points at the same time because we have to go through all module files anyway.
-    executors: List[Type["Executor"]] = [slurm.SlurmExecutor, local.LocalExecutor, debug.DebugExecutor]
-    job_envs = [slurm.SlurmJobEnvironment(), local.LocalJobEnvironment(), debug.DebugJobEnvironment()]
+    executors: List[Type["Executor"]] = [slurm.SlurmExecutor, local.LocalExecutor, debug.DebugExecutor, oar.OarExecutor]
+    job_envs = [slurm.SlurmJobEnvironment(), local.LocalJobEnvironment(), debug.DebugJobEnvironment(), oar.OarJobEnvironment()]
     for entry_point in pkg_resources.iter_entry_points("submitit"):
         if entry_point.name not in ("executor", "job_environment"):
             logger.warning(f"Found unknown entry point in package {entry_point.module_name}: {entry_point}")

--- a/submitit/core/submission.py
+++ b/submitit/core/submission.py
@@ -58,7 +58,7 @@ def process_job(folder: Union[Path, str]) -> None:
         with utils.temporary_save_path(paths.result_pickle) as tmppath:  # save somewhere else, and move
             utils.cloudpickle_dump(("success", result), tmppath)
             del result
-            logger.info("Exitting after successful completion")
+            logger.info("Exiting after successful completion")
     except Exception as error:  # TODO: check pickle methods for capturing traceback; pickling and raising
         try:
             with utils.temporary_save_path(paths.result_pickle) as tmppath:

--- a/submitit/oar/__init__.py
+++ b/submitit/oar/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/submitit/oar/oar.py
+++ b/submitit/oar/oar.py
@@ -361,11 +361,9 @@ class OarExecutor(core.PicklingExecutor):
         # we read from this temp file, and submit using an inline command.
         with open(submission_file_path) as f:
             submission_script_lines = f.readlines()
-        oarsub_options = [line[5:].strip() for line in submission_script_lines if line.startswith("#OAR ")]
-        oarsub_cmd = " ".join(["oarsub "] + oarsub_options)
-        inline_script_lines = [line for line in submission_script_lines if not line.startswith("#")]
-        inline_cmd = "".join(inline_script_lines)
-        return shlex.split(oarsub_cmd) + [inline_cmd]
+        oarsub_options = [item for line in submission_script_lines if line.startswith("#OAR ") for item in line[5:].split()]
+        inline_script_lines = [line.strip() for line in submission_script_lines if not line.startswith("#") and line != '\n']
+        return ["oarsub"] + oarsub_options + [ "; ".join(inline_script_lines) ]
 
     @staticmethod
     def _get_job_id_from_submission_command(string: Union[bytes, str]) -> str:

--- a/submitit/oar/oar.py
+++ b/submitit/oar/oar.py
@@ -15,7 +15,6 @@ import sys
 import typing as tp
 import uuid
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Set, Union
 
 from .. import helpers
 from ..core import core, job_environment, logger, utils
@@ -38,7 +37,7 @@ class OarInfoWatcher(core.InfoWatcher):
         "Resuming": " REQUEUED",
     }
 
-    def _make_command(self) -> Optional[List[str]]:
+    def _make_command(self) -> tp.Optional[tp.List[str]]:
         to_check = {x for x in self._registered - self._finished}
         if not to_check:
             return None
@@ -61,20 +60,21 @@ class OarInfoWatcher(core.InfoWatcher):
         info = self.get_info(job_id, mode=mode)
         return info.get("State") or "UNKNOWN"
 
-    def read_info(self, string: Union[bytes, str]) -> Dict[str, Dict[str, str]]:
+    def read_info(self, string: tp.Union[bytes, str]) -> tp.Dict[str, tp.Dict[str, str]]:
         """Reads the output of oarstat and returns a dictionary containing main information"""
-        all_stats: Dict[str, Dict[str, str]] = {}
+        all_stats: tp.Dict[str, tp.Dict[str, str]] = {}
         if string:
             if not isinstance(string, str):
                 string = string.decode()
             oarstat_output_dict = json.loads(string)
             if len(oarstat_output_dict) == 0:
                 return {}  # one job id does not exist (yet)
-            for k,v in oarstat_output_dict.items():
+            for k, v in oarstat_output_dict.items():
                 stat = {
                     "JobID": k,
                     "State": self.submitit_state_mapping.get(v.get("state")),
-                    "NodeList": v.get("assigned_network_address")}
+                    "NodeList": v.get("assigned_network_address"),
+                }
                 all_stats[k] = stat
         return all_stats
 
@@ -101,7 +101,7 @@ class OarJob(core.Job[core.R]):
         # in case of preemption, the job will be checkpointed with signal 12 (SIGUSR2)
         if not timeout:
             subprocess.check_call([self._cancel_command, "-s", "SIGTERM", self.job_id], shell=False)
-        subprocess.check_call([self._cancel_command, "-c" , self.job_id], shell=False)
+        subprocess.check_call([self._cancel_command, "-c", self.job_id], shell=False)
 
     def cancel(self, check: bool = True) -> None:
         """Cancels the job
@@ -119,12 +119,12 @@ class OarJob(core.Job[core.R]):
             self._get_cancel_command() + [self.job_id], shell=False
         )
 
-    def _get_cancel_command(self) -> List[str]:
+    def _get_cancel_command(self) -> tp.List[str]:
         if self._resubmitted_job is None:
             return [self._cancel_command]
         else:
             # "--array" ensure to delete the original job and the resubmitted ones
-            return [self._cancel_command, '--array']
+            return [self._cancel_command, "--array"]
 
     def done(self, force_check: bool = False) -> bool:
         """Checks whether the job is finished.
@@ -153,11 +153,11 @@ class OarJob(core.Job[core.R]):
             if super().done(force_check):
                 if self._get_resubmitted_job() is None:
                     return True
-            else:
-                return False
-        return self._resubmitted_job.done(force_check)
+            return False
+        else:
+            return self._resubmitted_job.done(force_check)
 
-    def _get_resubmitted_job(self) -> "OarJob[core.R]":
+    def _get_resubmitted_job(self) -> tp.Optional["OarJob[core.R]"]:
         """Returns the resubmitted job.
         If the job is not resubmitted, return None
         """
@@ -170,9 +170,16 @@ class OarJob(core.Job[core.R]):
                 # resubmitted_job_id is the key of the output_dict
                 resubmitted_job_id = next(iter(output_dict.keys()), None)
                 if resubmitted_job_id is not None:
-                    self._resubmitted_job = OarJob(folder=self._paths.folder, job_id=resubmitted_job_id, tasks=[0])
+                    self._resubmitted_job = OarJob(
+                        folder=self._paths.folder, job_id=resubmitted_job_id, tasks=[0]
+                    )
+                    return self._resubmitted_job
+                else:
+                    return None
             except Exception as e:
-                logger.get_logger().error(f"Getting error with _get_resubmitted_job() by command {command}:\n")
+                logger.get_logger().error(
+                    f"Getting error with _get_resubmitted_job() by command {command}:\n"
+                )
                 raise e
         return self._resubmitted_job
 
@@ -186,8 +193,12 @@ class OarJob(core.Job[core.R]):
             either "stdout" or "stderr"
         """
         string = super()._get_logs_string(name)
-        if self._get_resubmitted_job() is not None:
-            string += self._resubmitted_job._get_logs_string(name)
+        resubmitted_job = self._get_resubmitted_job()
+        if string is not None:
+            if resubmitted_job is not None:
+                resubmitted_logs = resubmitted_job._get_logs_string(name)
+                if resubmitted_logs is not None:
+                    string += resubmitted_logs
         return string
 
 
@@ -220,7 +231,7 @@ class OarExecutor(core.PicklingExecutor):
     job_class = OarJob
     watcher = OarInfoWatcher(delay_s=600)
 
-    def __init__(self, folder: Union[Path, str], max_num_timeout: int = 3) -> None:
+    def __init__(self, folder: tp.Union[Path, str], max_num_timeout: int = 3) -> None:
         super().__init__(folder, max_num_timeout=max_num_timeout)
         if not self.affinity() > 0:
             raise RuntimeError('Could not detect "oarsub", are you indeed on a OAR cluster?')
@@ -232,14 +243,17 @@ class OarExecutor(core.PicklingExecutor):
             "timeout_min": "timeout_min",
             "nodes": "nodes",
             "gpus_per_node": "gpu",
+            "mem_gb": "",
+            "cpus_per_task": "",
+            "tasks_per_node": "",
         }
 
     @classmethod
-    def _valid_parameters(cls) -> Set[str]:
+    def _valid_parameters(cls) -> tp.Set[str]:
         """Parameters that can be set through update_parameters"""
         return set(_get_default_parameters())
 
-    def _internal_update_parameters(self, **kwargs: Any) -> None:
+    def _internal_update_parameters(self, **kwargs: tp.Any) -> None:
         """Updates oar submission parameters
 
         Parameters
@@ -269,13 +283,13 @@ class OarExecutor(core.PicklingExecutor):
             raise ValueError(
                 f"Unavailable parameter(s): {in_valid_parameters}\nValid parameters are:\n  - {string}"
             )
-        if 'walltime' in kwargs:
+        if "walltime" in kwargs:
             # use updated OAR specific parameter walltime by default if present
-            kwargs['timeout_min'] = _oar_walltime_to_timeout_min(kwargs['walltime'])
-        elif 'timeout_min' in kwargs:
+            kwargs["timeout_min"] = _oar_walltime_to_timeout_min(kwargs["walltime"])
+        elif "timeout_min" in kwargs:
             # if shared parameter timeout_min is updated but not the OAR specific parameter walltime,
             # then convert timeout_min in minutes to [hour:min:sec|hour:min|hour] format for OAR.
-            kwargs['walltime'] = _timeout_min_to_oar_walltime(kwargs['timeout_min'])
+            kwargs["walltime"] = _timeout_min_to_oar_walltime(kwargs["timeout_min"])
         # check that new parameters are correct
         _make_oarsub_string(command="nothing to do", folder=self.folder, **kwargs)
         super()._internal_update_parameters(**kwargs)
@@ -285,16 +299,17 @@ class OarExecutor(core.PicklingExecutor):
         ex.update_parameters(**self.parameters)
         # set the OAR Job type to idempotent,
         # in this way, the checkpointed job will be resubmitted automatically by OAR.
-        ex.parameters.setdefault('additional_parameters', {})
-        ex.parameters['additional_parameters'].setdefault('t', [])
-        ex.parameters['additional_parameters']['t'].append('idempotent')
+        ex.parameters.setdefault("additional_parameters", {})
+        ex.parameters["additional_parameters"].setdefault("t", [])
+        ex.parameters["additional_parameters"]["t"].append("idempotent")
         return ex
 
     def _need_checkpointable_executor(self, delayed_submission: utils.DelayedSubmission):
-        return isinstance(delayed_submission.function, helpers.Checkpointable) and \
-                ('additional_parameters' not in self.parameters or \
-                't' not in self.parameters['additional_parameters'] or \
-                'idempotent' not in self.parameters['additional_parameters']['t'])
+        return isinstance(delayed_submission.function, helpers.Checkpointable) and (
+            "additional_parameters" not in self.parameters
+            or "t" not in self.parameters["additional_parameters"]
+            or "idempotent" not in self.parameters["additional_parameters"]["t"]
+        )
 
     def _internal_process_submissions(
         self, delayed_submissions: tp.List[utils.DelayedSubmission]
@@ -308,10 +323,13 @@ class OarExecutor(core.PicklingExecutor):
             return super()._internal_process_submissions(delayed_submissions)
         # array
         # delayed_submissions should be either all Checkpointable functions or all non Checkpointable functions
-        if any(isinstance(d.function, helpers.Checkpointable) for d in delayed_submissions) and \
-            any(not isinstance(d.function, helpers.Checkpointable) for d in delayed_submissions):
-            raise Exception("OarExecutor does not support a job array that mixes checkpointable and non-checkpointable functions."
-                            "\nPlease make groups of similar function calls in the job array.")
+        if any(isinstance(d.function, helpers.Checkpointable) for d in delayed_submissions) and any(
+            not isinstance(d.function, helpers.Checkpointable) for d in delayed_submissions
+        ):
+            raise Exception(
+                "OarExecutor does not support a job array that mixes checkpointable and non-checkpointable functions."
+                "\nPlease make groups of similar function calls in the job array."
+            )
         folder = utils.JobPaths.get_first_id_independent_folder(self.folder)
         folder.mkdir(parents=True, exist_ok=True)
         timeout_min = self.parameters.get("timeout_min", 5)
@@ -334,9 +352,9 @@ class OarExecutor(core.PicklingExecutor):
 
         first_job: core.Job[tp.Any] = array_ex._submit_command(self._submitit_command_str)
         jobIdList = self._get_job_id_list_from_array_id(first_job.job_id)
-        jobs: List[core.Job[tp.Any]] = [
+        jobs: tp.List[core.Job[tp.Any]] = [
             OarJob(folder=self.folder, job_id=f"{jid}", tasks=[0]) for jid in jobIdList
-        ] # only single task is supported for the moment.
+        ]  # only single task is supported for the moment.
         for job, pickle_path in zip(jobs, pickle_paths):
             job.paths.move_temporary_file(pickle_path, "submitted_pickle")
         return jobs
@@ -353,7 +371,7 @@ class OarExecutor(core.PicklingExecutor):
     def _make_submission_file_text(self, command: str, uid: str) -> str:
         return _make_oarsub_string(command=command, folder=self.folder, **self.parameters)
 
-    def _make_submission_command(self, submission_file_path: Path) -> List[str]:
+    def _make_submission_command(self, submission_file_path: Path) -> tp.List[str]:
         # For OAR cluster, the submission file needs to exist at the submission time
         # AND at the job launch time.
         # That's why we should override this parameter of _submit_command method from PicklingExecutor.
@@ -361,12 +379,16 @@ class OarExecutor(core.PicklingExecutor):
         # we read from this temp file, and submit using an inline command.
         with open(submission_file_path) as f:
             submission_script_lines = f.readlines()
-        oarsub_options = [item for line in submission_script_lines if line.startswith("#OAR ") for item in line[5:].split()]
-        inline_script_lines = [line.strip() for line in submission_script_lines if not line.startswith("#") and line != '\n']
-        return ["oarsub"] + oarsub_options + [ "; ".join(inline_script_lines) ]
+        oarsub_options = [
+            item for line in submission_script_lines if line.startswith("#OAR ") for item in line[5:].split()
+        ]
+        inline_script_lines = [
+            line.strip() for line in submission_script_lines if not line.startswith("#") and line != "\n"
+        ]
+        return ["oarsub"] + oarsub_options + ["; ".join(inline_script_lines)]
 
     @staticmethod
-    def _get_job_id_from_submission_command(string: Union[bytes, str]) -> str:
+    def _get_job_id_from_submission_command(string: tp.Union[bytes, str]) -> str:
         """Returns the job ID from the output of oarsub string"""
         if not isinstance(string, str):
             string = string.decode()
@@ -383,7 +405,7 @@ class OarExecutor(core.PicklingExecutor):
     def affinity(cls) -> int:
         return -1 if shutil.which("oarsub") is None else 2
 
-    def _get_job_id_list_from_array_id(self, array_id) -> [str]:
+    def _get_job_id_list_from_array_id(self, array_id) -> tp.List[str]:
         """Returns the list of OAR jobid of a job array"""
         command = ["oarstat", "--array", array_id, "-J"]
         try:
@@ -392,15 +414,17 @@ class OarExecutor(core.PicklingExecutor):
             output_dict = self.watcher.read_info(output)
             return sorted(list(output_dict.keys()))
         except Exception as e:
-            logger.get_logger().error(f"Getting error with _get_job_id_list_from_array_id() by command {command}:\n")
+            logger.get_logger().error(
+                f"Getting error with _get_job_id_list_from_array_id() by command {command}:\n"
+            )
             raise e
 
 
 @functools.lru_cache()
-def _get_default_parameters() -> Dict[str, Any]:
+def _get_default_parameters() -> tp.Dict[str, tp.Any]:
     """Parameters that can be set through update_parameters"""
     specs = inspect.getfullargspec(_make_oarsub_string)
-    zipped = zip(specs.args[-len(specs.defaults) :], specs.defaults) # type: ignore
+    zipped = zip(specs.args[-len(specs.defaults) :], specs.defaults)  # type: ignore
     return {key: val for key, val in zipped if key not in {"command", "folder", "map_count"}}
 
 
@@ -418,7 +442,7 @@ def _make_oarsub_string(
     setup: tp.Optional[tp.List[str]] = None,
     n: str = "submitit",
     stderr_to_stdout: bool = False,
-    additional_parameters: tp.Optional[tp.Dict[str, tp.Union[List[str], str]]] = None,
+    additional_parameters: tp.Optional[tp.Dict[str, tp.Union[tp.List[str], str]]] = None,
 ) -> str:
     """Creates the content of a bash file with provided parameters
 
@@ -444,7 +468,7 @@ def _make_oarsub_string(
         In case an erroneous keyword argument is added, a list of all eligible parameters
         is printed, with their default values
     """
-    parameters = {}
+    parameters: tp.Dict[str, tp.Any] = {}
     # resource request passed to the "-l" option
     # OAR needs to have the resource request on a single line, otherwise it is considered as a moldable job.
     # OAR resource hierarchy: nodes > gpu > core
@@ -454,7 +478,7 @@ def _make_oarsub_string(
     if gpu is not None:
         resource_hierarchy += "/gpu=%d" % gpu
     if core is not None:
-        resource_hierarchy +=  "/core=%d" % core
+        resource_hierarchy += "/core=%d" % core
     if walltime is not None:
         walltime = "walltime=%s" % walltime
     resource_request = ",".join(filter(None, (resource_hierarchy, walltime)))
@@ -468,13 +492,16 @@ def _make_oarsub_string(
     # stdout and stderr passed to OAR "-O" and "-E" options
     paths = utils.JobPaths(folder=folder)
     parameters["O"] = str(paths.stdout).replace("%j", "%jobid%").replace("%t", "0")
-    parameters["E"] = parameters["O"] if stderr_to_stdout else str(paths.stderr).replace("%j", "%jobid%").replace("%t", "0")
+    parameters["E"] = (
+        parameters["O"] if stderr_to_stdout else str(paths.stderr).replace("%j", "%jobid%").replace("%t", "0")
+    )
     if map_count is not None:
         assert isinstance(map_count, int)
-        parameters["array"] = map_count
+        parameters["array"] = str(map_count)
     # additional parameters passed here
     if additional_parameters is not None:
-        parameters.update(additional_parameters)
+        for k, v in additional_parameters.items():
+            parameters[k] = v
     # now create the bash file with OAR options
     lines = ["#!/bin/bash", "", "# Parameters"]
     for k in sorted(parameters):
@@ -506,7 +533,7 @@ def _timeout_min_to_oar_walltime(timeout_min: int) -> str:
 
 def _oar_walltime_to_timeout_min(walltime: str) -> int:
     # Split the walltime string in [hour:min:sec|hour:min|hour] format
-    parts = walltime.split(':')
+    parts = walltime.split(":")
     hours = int(parts[0])
     minutes = int(parts[1]) if len(parts) > 1 else 0
     seconds = int(parts[2]) if len(parts) > 2 else 0
@@ -526,7 +553,7 @@ class OarJobEnvironment(job_environment.JobEnvironment):
     }
 
     @property
-    def hostnames(self) -> List[str]:
+    def hostnames(self) -> tp.List[str]:
         # Parse the content of the "OAR_NODEFILE" environment variable,
         # which gives access to the list of hostnames that are part of the current job.
         nodes_file_path = os.environ.get(self._env["nodes"], "")
@@ -541,10 +568,11 @@ class OarJobEnvironment(job_environment.JobEnvironment):
             return [self.hostname]
 
     @property
-    def array_task_id(self) -> Optional[str]:
-        if os.environ.get(self._env["array_task_id"]):
+    def array_task_id(self) -> tp.Optional[str]:
+        array_task_id_str = os.environ.get(self._env["array_task_id"])
+        if array_task_id_str is not None:
             # For OAR, OAR_ARRAY_INDEX starts from 1 (not 0) initially
-            return str(int(os.environ.get(self._env["array_task_id"])) -1)
+            return str(int(array_task_id_str) - 1)
         return None
 
     @property
@@ -552,7 +580,7 @@ class OarJobEnvironment(job_environment.JobEnvironment):
         """Total number of nodes for the job:"""
         # For OAR, the "num_nodes" environment variable does not exist.
         # We count the number of hostnames for the current job.
-        if not self.hostnames:
+        if self.hostnames is None:
             return 1
         return len(self.hostnames)
 

--- a/submitit/oar/oar.py
+++ b/submitit/oar/oar.py
@@ -249,8 +249,8 @@ class OarExecutor(core.PicklingExecutor):
 
         Below are the parameters that differ from OAR documentation:
 
-        folder: str/Path
-            folder where print logs and error logs will be written
+        setup: list
+            a list of command to run in sbatch before running srun
         additional_parameters: dict
             add OAR parameters which are not currently available in submitit.
             Eg: {"t": ["besteffort", "idempotent"]} will be prepended as "#OAR -t besteffort -t idempotent" in the OAR submition file.
@@ -417,6 +417,7 @@ def _make_oarsub_string(
     walltime: tp.Optional[str] = None,
     timeout_min: tp.Optional[int] = None,
     queue: tp.Optional[str] = None,
+    setup: tp.Optional[tp.List[str]] = None,
     n: str = "submitit",
     additional_parameters: tp.Optional[tp.Dict[str, tp.Union[List[str], str]]] = None,
 ) -> str:
@@ -431,6 +432,8 @@ def _make_oarsub_string(
 
     folder: str/Path
         folder where print logs and error logs will be written
+    setup: list
+        a list of command to run in sbatch befure running srun
     additional_parameters: dict
         add OAR parameters which are not currently available in submitit.
         Eg: {"t": ["besteffort", "idempotent"]} will be prepended as "#OAR -t besteffort -t idempotent" in the OAR submition file.
@@ -477,6 +480,9 @@ def _make_oarsub_string(
     lines = ["#!/bin/bash", "", "# Parameters"]
     for k in sorted(parameters):
         lines.append(_as_oar_flag(k, parameters[k]))
+    # environment setup:
+    if setup is not None:
+        lines += ["", "# setup"] + setup
     lines += ["", "# command", "export SUBMITIT_EXECUTOR=oar", command, ""]
     return "\n".join(lines)
 

--- a/submitit/oar/oar.py
+++ b/submitit/oar/oar.py
@@ -1,0 +1,384 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import functools
+import inspect
+import json
+import os
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+import typing as tp
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Set, Union
+
+from ..core import core, job_environment, utils
+
+
+class OarInfoWatcher(core.InfoWatcher):
+    def _make_command(self) -> Optional[List[str]]:
+        # asking for array id will return all status
+        # on the other end, asking for each and every one of them individually takes a huge amount of time
+        to_check = {x for x in self._registered - self._finished}
+        if not to_check:
+            return None
+        command = ["oarstat", "-f", "-J"]
+        for jid in to_check:
+            command.extend(["-j", str(jid)])
+        return command
+
+    def get_state(self, job_id: str, mode: str = "standard") -> str:
+        """Returns the state of the job
+        State of finished jobs are cached (use watcher.clear() to remove all cache)
+
+        Parameters
+        ----------
+        job_id: int
+            id of the job on the cluster
+        mode: str
+            one of "force" (forces a call), "standard" (calls regularly) or "cache" (does not call)
+        """
+        info = self.get_info(job_id, mode=mode)
+        return info.get("State") or "UNKNOWN"
+
+    def read_info(self, string: Union[bytes, str]) -> Dict[str, Dict[str, str]]:
+        """Reads the output of oarstat and returns a dictionary containing main information"""
+        all_stats: Dict[str, Dict[str, str]] = {}
+        if string:
+            if not isinstance(string, str):
+                string = string.decode()
+            oarstat_output_dict = json.loads(string)
+            if len(oarstat_output_dict) == 0:
+                return {}  # one job id does not exist (yet)
+            for k,v in oarstat_output_dict.items():
+                stat = {"JobID": k, "State": v.get("state"), "NodeList": v.get("assigned_network_address")}
+                all_stats[k] = stat
+        return all_stats
+
+    def is_done(self, job_id: str, mode: str = "standard") -> bool:
+        """Returns whether the job is finished.
+
+        Parameters
+        ----------
+        job_id: str
+            id of the job on the cluster
+        mode: str
+            one of "force" (forces a call), "standard" (calls regularly) or "cache" (does not call)
+        """
+        state = self.get_state(job_id, mode=mode)
+        return state not in ["Waiting", "Hold", "Launching", "Running", "Suspended", "Resuming", "Finishing", "UNKNOWN"]
+
+
+class OarJob(core.Job[core.R]):
+
+    _cancel_command = "oardel"
+    watcher = OarInfoWatcher(delay_s=600)
+
+    def _interrupt(self, timeout: bool = False) -> None:
+        """Sends preemption or timeout signal to the job (for testing purpose)
+
+        Parameter
+        ---------
+        timeout: bool
+            Whether to trigger a job time-out (if False, it triggers preemption)
+        """
+        # in case of preemption, the job will be checkpointed with signal 12 (SIGUSR2)
+        if not timeout:
+            subprocess.check_call([self._cancel_command, "-s", "SIGTERM", self.job_id], shell=False)
+        subprocess.check_call([self._cancel_command, "-c" , self.job_id], shell=False)
+
+
+class OarExecutor(core.PicklingExecutor):
+    """Oar job executor
+    This class is used to hold the parameters to run a job on OAR.
+    In practice, it will create a batch file in the specified directory for each job,
+    and pickle the task function and parameters. At completion, the job will also pickle
+    the output. Logs are also dumped in the same directory.
+
+    Parameters
+    ----------
+    folder: Path/str
+        folder for storing job submission/output and logs.
+    max_num_timeout: int
+        Maximum number of time the job can be requeued after timeout (if
+        the instance is derived from helpers.Checkpointable)
+
+    Note
+    ----
+    - be aware that the log/output folder will be full of logs and pickled objects very fast,
+      it may need cleaning.
+    - the folder needs to point to a directory shared through the cluster. This is typically
+      not the case for your tmp! If you try to use it, it will fail silently (since it
+      will not even be able to log stderr).
+    - use update_parameters to specify custom parameters (queue etc...). If you
+      input erroneous parameters, an error will print all parameters available for you.
+    """
+
+    job_class = OarJob
+
+    def __init__(self, folder: Union[Path, str], max_num_timeout: int = 3) -> None:
+        super().__init__(folder, max_num_timeout=max_num_timeout)
+        if not self.affinity() > 0:
+            raise RuntimeError('Could not detect "oarsub", are you indeed on a OAR cluster?')
+
+    @classmethod
+    def _equivalence_dict(cls) -> core.EquivalenceDict:
+        return {
+            "name": "n",
+            "timeout_min": "timeout_min",
+            "nodes": "nodes",
+            "gpus_per_node": "gpu",
+        }
+
+    @classmethod
+    def _valid_parameters(cls) -> Set[str]:
+        """Parameters that can be set through update_parameters"""
+        return set(_get_default_parameters())
+
+    def _internal_update_parameters(self, **kwargs: Any) -> None:
+        """Updates oar submission parameters
+
+        Parameters
+        ----------
+        See oar documentation for most parameters.
+        Most useful parameters are: core, walltime, gpu, queue.
+
+        Below are the parameters that differ from OAR documentation:
+
+        folder: str/Path
+            folder where print logs and error logs will be written
+        additional_parameters: dict
+            add OAR parameters which are not currently available in submitit.
+            Eg: {"t": ["besteffort", "idempotent"]} will be prepended as "#OAR -t besteffort -t idempotent" in the OAR submition file.
+            Eg: {"p": "'chetemi AND memcore>=3337'"} will be prepended as "#OAR -p 'chetemi AND memcore>=3337'" in the OAR submission file.
+
+        Raises
+        ------
+        ValueError
+            In case an erroneous keyword argument is added, a list of all eligible parameters
+            is printed, with their default values
+        """
+        defaults = _get_default_parameters()
+        in_valid_parameters = sorted(set(kwargs) - set(defaults))
+        if in_valid_parameters:
+            string = "\n  - ".join(f"{x} (default: {repr(y)})" for x, y in sorted(defaults.items()))
+            raise ValueError(
+                f"Unavailable parameter(s): {in_valid_parameters}\nValid parameters are:\n  - {string}"
+            )
+        if 'walltime' in kwargs:
+            # use updated OAR specific parameter walltime by default if present
+            kwargs['timeout_min'] = _oar_walltime_to_timeout_min(kwargs['walltime'])
+        elif 'timeout_min' in kwargs:
+            # if shared parameter timeout_min is updated but not the OAR specific parameter walltime,
+            # then convert timeout_min in minutes to [hour:min:sec|hour:min|hour] format for OAR.
+            kwargs['walltime'] = _timeout_min_to_oar_walltime(kwargs['timeout_min'])
+        # check that new parameters are correct
+        _make_oarsub_string(command="nothing to do", folder=self.folder, **kwargs)
+        super()._internal_update_parameters(**kwargs)
+
+    def _internal_process_submissions(
+        self, delayed_submissions: tp.List[utils.DelayedSubmission]
+    ) -> tp.List[core.Job[tp.Any]]:
+        if len(delayed_submissions) == 1:
+            return super()._internal_process_submissions(delayed_submissions)
+        #TODO deal with job array
+        raise NotImplementedError
+
+    @property
+    def _submitit_command_str(self) -> str:
+        return " ".join(
+            [shlex.quote(sys.executable), "-u -m submitit.core._submit", shlex.quote(str(self.folder))]
+        )
+
+    def _num_tasks(self) -> int:
+        return 1
+
+    def _make_submission_file_text(self, command: str, uid: str) -> str:
+        return _make_oarsub_string(command=command, folder=self.folder, **self.parameters)
+
+    def _make_submission_command(self, submission_file_path: Path) -> List[str]:
+        # For OAR cluster, the submission file needs to exist at the submission time
+        # AND at the job launch time.
+        # That's why we should override this parameter of _submit_command method from PicklingExecutor.
+        # Instead of submitting using the temp submission file,
+        # we read from this temp file, and submit using an inline command.
+        with open(submission_file_path) as f:
+            submission_script_lines = f.readlines()
+        oarsub_options = [line[5:].strip() for line in submission_script_lines if line.startswith("#OAR ")]
+        oarsub_cmd = " ".join(["oarsub "] + oarsub_options)
+        inline_script_lines = [line for line in submission_script_lines if not line.startswith("#")]
+        inline_cmd = "".join(inline_script_lines)
+        return shlex.split(oarsub_cmd) + [inline_cmd]
+
+    @staticmethod
+    def _get_job_id_from_submission_command(string: Union[bytes, str]) -> str:
+        """Returns the job ID from the output of oarsub string"""
+        if not isinstance(string, str):
+            string = string.decode()
+        output = re.search(r"OAR_JOB_ID=(?P<id>[0-9]+)", string)
+        if output is None:
+            raise utils.FailedSubmissionError(
+                f'Could not make sense of oarsub output "{string}"\n'
+                "Job instance will not be able to fetch status\n"
+                "(you may however set the job job_id manually if needed)"
+            )
+        return output.group("id")
+
+    @classmethod
+    def affinity(cls) -> int:
+        return -1 if shutil.which("oarsub") is None else 2
+
+
+@functools.lru_cache()
+def _get_default_parameters() -> Dict[str, Any]:
+    """Parameters that can be set through update_parameters"""
+    specs = inspect.getfullargspec(_make_oarsub_string)
+    zipped = zip(specs.args[-len(specs.defaults) :], specs.defaults) # type: ignore
+    return {key: val for key, val in zipped if key not in {"command", "folder", "map_count"}}
+
+
+# pylint: disable=too-many-arguments,unused-argument, too-many-locals
+def _make_oarsub_string(
+    command: str,
+    folder: tp.Union[str, Path],
+    nodes: tp.Optional[int] = None,
+    core: tp.Optional[int] = None,
+    gpu: tp.Optional[int] = None,
+    walltime: tp.Optional[str] = None,
+    timeout_min: tp.Optional[int] = None,
+    queue: tp.Optional[str] = None,
+    n: str = "submitit",
+    additional_parameters: tp.Optional[tp.Dict[str, tp.Union[List[str], str]]] = None,
+) -> str:
+    """Creates the content of a bash file with provided parameters
+
+    Parameters
+    ----------
+    See oar documentation for most parameters.
+    Most useful parameters are: core, walltime, gpu, queue.
+
+    Below are the parameters that differ from OAR documentation:
+
+    folder: str/Path
+        folder where print logs and error logs will be written
+    additional_parameters: dict
+        add OAR parameters which are not currently available in submitit.
+        Eg: {"t": ["besteffort", "idempotent"]} will be prepended as "#OAR -t besteffort -t idempotent" in the OAR submition file.
+        Eg: {"p": "'chetemi AND memcore>=3337'"} will be prepended as "#OAR -p 'chetemi AND memcore>=3337'" in the OAR submission file.
+
+    Raises
+    ------
+    ValueError
+        In case an erroneous keyword argument is added, a list of all eligible parameters
+        is printed, with their default values
+    """
+    parameters = {}
+    # resource request passed to the "-l" option
+    # OAR needs to have the resource request on a single line, otherwise it is considered as a moldable job.
+    # OAR resource hierarchy: nodes > gpu > core
+    resource_hierarchy = ""
+    if nodes is not None:
+        resource_hierarchy = "/nodes=%d" % nodes
+    if gpu is not None:
+        resource_hierarchy += "/gpu=%d" % gpu
+    if core is not None:
+        resource_hierarchy +=  "/core=%d" % core
+    if walltime is not None:
+        walltime = "walltime=%s" % walltime
+    resource_request = ",".join(filter(None, (resource_hierarchy, walltime)))
+    if resource_request:
+        parameters["l"] = resource_request
+    # queue parameter passed to the "-q" option
+    if queue is not None:
+        parameters["q"] = queue
+    # name parameter passed to the "-n" option
+    parameters["n"] = n
+    # stdout and stderr passed to OAR "-O" and "-E" options
+    paths = utils.JobPaths(folder=folder)
+    parameters["O"] = str(paths.stdout).replace("%j", "%jobid%").replace("%t", "0")
+    parameters["E"] = str(paths.stderr).replace("%j", "%jobid%").replace("%t", "0")
+    # additional parameters passed here
+    if additional_parameters is not None:
+        parameters.update(additional_parameters)
+    # now create the bash file with OAR options
+    lines = ["#!/bin/bash", "", "# Parameters"]
+    for k in sorted(parameters):
+        lines.append(_as_oar_flag(k, parameters[k]))
+    lines += ["", "# command", "export SUBMITIT_EXECUTOR=oar", command, ""]
+    return "\n".join(lines)
+
+
+def _as_oar_flag(key: str, value: tp.Any) -> str:
+    key = key.replace("_", "-")
+    if isinstance(value, list):
+        values = " ".join(f"-{key} {v}" for v in value)
+        return f"#OAR {values}"
+    elif isinstance(value, str):
+        return f"#OAR -{key} {value}"
+    else:
+        return f"#OAR -{key} {str(value)}"
+
+
+def _timeout_min_to_oar_walltime(timeout_min: int) -> str:
+    hour = timeout_min // 60
+    minute = timeout_min - hour * 60
+    return f"{hour:02}:{minute:02}"
+
+
+def _oar_walltime_to_timeout_min(walltime: str) -> int:
+    # Split the walltime string in [hour:min:sec|hour:min|hour] format
+    parts = walltime.split(':')
+    hours = int(parts[0])
+    minutes = int(parts[1]) if len(parts) > 1 else 0
+    seconds = int(parts[2]) if len(parts) > 2 else 0
+    return hours * 60 + minutes + round(seconds / 60)
+
+
+class OarJobEnvironment(job_environment.JobEnvironment):
+
+    _env = {
+        "job_id": "OAR_JOB_ID",
+        "nodes": "OAR_NODEFILE",
+        "array_task_id": "OAR_ARRAY_INDEX",
+        "num_tasks": "",
+        "local_rank": "",
+        "global_rank": "",
+    }
+
+    @property
+    def hostnames(self) -> List[str]:
+        # Parse the content of the "OAR_NODEFILE" environment variable,
+        # which gives access to the list of hostnames that are part of the current job.
+        nodes_file_path = os.environ.get(self._env["nodes"], "")
+        if os.path.exists(nodes_file_path):
+            with open(nodes_file_path) as f:
+                # read lines and remove duplicates
+                node_list = list(set(f.readlines()))
+            # remove the end of line "\n" for hostnames list
+            # and sort the hostnames list in alphabetical order
+            return sorted([n.strip() for n in node_list])
+        else:
+            return [self.hostname]
+
+    @property
+    def num_nodes(self) -> int:
+        """Total number of nodes for the job:"""
+        # For OAR, the "num_nodes" environment variable does not exist.
+        # We count the number of hostnames for the current job.
+        if not self.hostnames:
+            return 1
+        return len(self.hostnames)
+
+    @property
+    def node(self) -> int:
+        """Id of the current node:"""
+        # For OAR, the "node" environment variable does not exist.
+        # We sort the hostnames of one job in alphabetical order,
+        # and then return the index of hostname in the hostnames list.
+        if not self.hostnames or self.hostname not in self.hostnames:
+            return 0
+        return self.hostnames.index(self.hostname)

--- a/submitit/oar/oar.py
+++ b/submitit/oar/oar.py
@@ -419,6 +419,7 @@ def _make_oarsub_string(
     queue: tp.Optional[str] = None,
     setup: tp.Optional[tp.List[str]] = None,
     n: str = "submitit",
+    stderr_to_stdout: bool = False,
     additional_parameters: tp.Optional[tp.Dict[str, tp.Union[List[str], str]]] = None,
 ) -> str:
     """Creates the content of a bash file with provided parameters
@@ -469,7 +470,7 @@ def _make_oarsub_string(
     # stdout and stderr passed to OAR "-O" and "-E" options
     paths = utils.JobPaths(folder=folder)
     parameters["O"] = str(paths.stdout).replace("%j", "%jobid%").replace("%t", "0")
-    parameters["E"] = str(paths.stderr).replace("%j", "%jobid%").replace("%t", "0")
+    parameters["E"] = parameters["O"] if stderr_to_stdout else str(paths.stderr).replace("%j", "%jobid%").replace("%t", "0")
     if map_count is not None:
         assert isinstance(map_count, int)
         parameters["-array"] = map_count

--- a/submitit/oar/oar.py
+++ b/submitit/oar/oar.py
@@ -450,7 +450,7 @@ def _make_oarsub_string(
     # OAR resource hierarchy: nodes > gpu > core
     resource_hierarchy = ""
     if nodes is not None:
-        resource_hierarchy = "/nodes=%d" % nodes
+        resource_hierarchy += "/nodes=%d" % nodes
     if gpu is not None:
         resource_hierarchy += "/gpu=%d" % gpu
     if core is not None:
@@ -471,7 +471,7 @@ def _make_oarsub_string(
     parameters["E"] = parameters["O"] if stderr_to_stdout else str(paths.stderr).replace("%j", "%jobid%").replace("%t", "0")
     if map_count is not None:
         assert isinstance(map_count, int)
-        parameters["-array"] = map_count
+        parameters["array"] = map_count
     # additional parameters passed here
     if additional_parameters is not None:
         parameters.update(additional_parameters)
@@ -487,14 +487,15 @@ def _make_oarsub_string(
 
 
 def _as_oar_flag(key: str, value: tp.Any) -> str:
-    key = key.replace("_", "-")
-    if isinstance(value, list):
-        values = " ".join(f"-{key} {v}" for v in value)
-        return f"#OAR {values}"
-    elif isinstance(value, str):
-        return f"#OAR -{key} {value}"
+    if len(key) == 1:
+        key = f"-{key}"
     else:
-        return f"#OAR -{key} {str(value)}"
+        key = f"--{key}"
+    if isinstance(value, list):
+        values = " ".join(f"{key} {v}" for v in value)
+        return f"#OAR {values}"
+    else:
+        return f"#OAR {key} {value}"
 
 
 def _timeout_min_to_oar_walltime(timeout_min: int) -> str:

--- a/submitit/oar/test_oar.py
+++ b/submitit/oar/test_oar.py
@@ -1,0 +1,326 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+import contextlib
+import os
+import subprocess
+import typing as tp
+from pathlib import Path
+from typing import Any, Dict, Iterator, Optional, Sequence
+from unittest.mock import patch
+
+import pytest
+
+import submitit
+
+from ..core import job_environment, submission, test_core, utils
+from ..core.core import Job
+from . import oar
+
+
+# pylint: disable=no-self-use
+class MockedSubprocess:
+    """Helper for mocking subprocess calls"""
+
+    OARSTAT_JOB = '{{"{j}" : {{"state" : "{state}"}}}}'
+
+    def __init__(self, known_cmds: Sequence[str] = None) -> None:
+        self.job_oarstat: Dict[str, str] = {}
+        self.last_job: str = ""
+        self._subprocess_check_output = subprocess.check_output
+        self.known_cmds = known_cmds or []
+        self.job_count = 12
+
+    def __call__(self, command: Sequence[str], **kwargs: Any) -> bytes:
+        program = command[0]
+        if program in ["oarstat", "oarsub", "oardel"]:
+            return getattr(self, program)(command[1:]).encode()
+        elif program == "tail":
+            return self._subprocess_check_output(command, **kwargs)
+        else:
+            raise ValueError(f'Unknown command to mock "{command}".')
+
+    def oarstat(self, _: Sequence[str]) -> str:
+        return "\n".join(self.job_oarstat.values())
+
+    def oarsub(self, args: Sequence[str]) -> str:
+        """Create a "Running" job."""
+        job_id = str(self.job_count)
+        self.job_count += 1
+        self.set_job_state(job_id, "Running", 0)
+        return f"OAR_JOB_ID={job_id}\n"
+
+    def oardel(self, _: Sequence[str]) -> str:
+        # TODO:should we call set_job_state ?
+        return ""
+
+    def set_job_state(self, job_id: str, state: str, array: int = 0) -> None:
+        self.job_oarstat[job_id] = self._oarstat(state, job_id, array)
+        self.last_job = job_id
+
+    def _oarstat(self, state: str, job_id: str, array: int) -> str:
+        if array == 0:
+            lines = self.OARSTAT_JOB.format(j=job_id, state=state)
+        else:
+            lines = "\n".join(self.OARSTAT_JOB.format(j=f"{job_id}_{i}", state=state) for i in range(array))
+        return lines
+
+    def which(self, name: str) -> Optional[str]:
+        return "here" if name in self.known_cmds else None
+
+    def mock_cmd_fn(self, *args, **_):
+        # CommandFunction(cmd)() ~= subprocess.check_output(cmd)
+        return lambda: self(*args)
+
+    @contextlib.contextmanager
+    def context(self) -> Iterator[None]:
+        with patch("submitit.core.utils.CommandFunction", new=self.mock_cmd_fn):
+            with patch("subprocess.check_output", new=self):
+                with patch("shutil.which", new=self.which):
+                    with patch("subprocess.check_call", new=self):
+                        yield None
+
+    @contextlib.contextmanager
+    def job_context(self, job_id: str) -> Iterator[None]:
+        with utils.environment_variables(
+            _USELESS_TEST_ENV_VAR_="1", SUBMITIT_EXECUTOR="oar", OAR_JOB_ID=str(job_id)
+        ):
+            yield None
+
+
+def _mock_log_files(job: Job[tp.Any], prints: str = "", errors: str = "") -> None:
+    """Write fake log files"""
+    filepaths = [str(x).replace("%j", str(job.job_id)) for x in [job.paths.stdout, job.paths.stderr]]
+    for filepath, msg in zip(filepaths, (prints, errors)):
+        with Path(filepath).open("w") as f:
+            f.write(msg)
+
+
+@contextlib.contextmanager
+def mocked_oar() -> tp.Iterator[MockedSubprocess]:
+    mock = MockedSubprocess(known_cmds=["oarsub"])
+    try:
+        with mock.context():
+            yield mock
+    finally:
+        # Clear the state of the shared watcher
+        oar.OarJob.watcher.clear()
+
+
+def test_mocked_missing_state(tmp_path: Path) -> None:
+    with mocked_oar() as mock:
+        mock.set_job_state("12", "")
+        job: oar.OarJob[None] = oar.OarJob(tmp_path, "12")
+        assert job.state == "UNKNOWN"
+        job._interrupt(timeout=False)  # check_call is bypassed by MockedSubprocess
+
+
+def test_job_environment() -> None:
+    with mocked_oar() as mock:
+        mock.set_job_state("12", "Running")
+        with mock.job_context("12"):
+            assert job_environment.JobEnvironment().cluster == "oar"
+
+
+def test_oar_job_mocked(tmp_path: Path) -> None:
+    with mocked_oar() as mock:
+        executor = oar.OarExecutor(folder=tmp_path)
+        job = executor.submit(test_core.do_nothing, 1, 2, blublu=3)
+        # First mock job always have id 12
+        assert job.job_id == "12"
+        assert job.state == "Running"
+        assert job.stdout() is None
+        _mock_log_files(job, errors="This is the error log\n", prints="hop")
+        job._results_timeout_s = 0
+        with pytest.raises(utils.UncompletedJobError):
+            job._get_outcome_and_result()
+        _mock_log_files(job, errors="This is the error log\n", prints="hop")
+
+        with mock.job_context(job.job_id):
+            submission.process_job(job.paths.folder)
+        assert job.result() == 12
+        # logs
+        assert job.stdout() == "hop"
+        assert job.stderr() == "This is the error log\n"
+        assert "_USELESS_TEST_ENV_VAR_" not in os.environ, "Test context manager seems to be failing"
+
+
+def test_oar_error_mocked(tmp_path: Path) -> None:
+    with mocked_oar() as mock:
+        executor = oar.OarExecutor(folder=tmp_path)
+        executor.update_parameters(walltime="0:0:5", queue="default")  # just to cover the function
+        job = executor.submit(test_core.do_nothing, 1, 2, error=12)
+        with mock.job_context(job.job_id):
+            with pytest.raises(ValueError):
+                submission.process_job(job.paths.folder)
+        _mock_log_files(job, errors="This is the error log\n")
+        with pytest.raises(utils.FailedJobError):
+            job.result()
+        exception = job.exception()
+        assert isinstance(exception, utils.FailedJobError)
+
+
+def test_make_oarsub_string() -> None:
+    string = oar._make_oarsub_string(
+        command="blublu bar",
+        folder="/tmp",
+        queue="default",
+        additional_parameters=dict({"t": "besteffort"}),
+    )
+    assert "q" in string
+    assert "-t besteffort" in string
+    assert "nodes" not in string
+    assert "core" not in string
+    assert "gpu" not in string
+    assert "--command" not in string
+    record_file = Path(__file__).parent / "_oarsub_test_record.txt"
+    if not record_file.exists():
+        record_file.write_text(string)
+    recorded = record_file.read_text()
+    changes = []
+    for k, (line1, line2) in enumerate(zip(string.splitlines(), recorded.splitlines())):
+        if line1 != line2:
+            changes.append(f'line #{k + 1}: "{line2}" -> "{line1}"')
+    if changes:
+        print(string)
+        print("# # # # #")
+        print(recorded)
+        message = ["Difference with reference file:"] + changes
+        message += ["", "Delete the record file if this is normal:", f"rm {record_file}"]
+        raise AssertionError("\n".join(message))
+
+
+def test_make_oarsub_string_gpu() -> None:
+    string = oar._make_oarsub_string(command="blublu", folder="/tmp", gpu=2)
+    assert "-l /gpu=2" in string
+
+
+def test_make_oarsub_string_core() -> None:
+    string = oar._make_oarsub_string(command="blublu", folder="/tmp", core=2)
+    assert "-l /core=2" in string
+
+
+def test_make_oarsub_string_gpu_and_nodes() -> None:
+    string = oar._make_oarsub_string(command="blublu", folder="/tmp", gpu=2, nodes=1)
+    assert "-l /nodes=1/gpu=2" in string
+
+
+def test_make_oarsub_string_core_and_nodes() -> None:
+    string = oar._make_oarsub_string(command="blublu", folder="/tmp", core=2, nodes=1)
+    assert "-l /nodes=1/core=2" in string
+
+
+def test_make_oarsub_string_core_gpu_and_nodes() -> None:
+    string = oar._make_oarsub_string(command="blublu", folder="/tmp", gpu=2, nodes=1, core=4)
+    assert "-l /nodes=1/gpu=2/core=4" in string
+
+
+def test_update_parameters(tmp_path: Path) -> None:
+    with mocked_oar():
+        executor = submitit.AutoExecutor(folder=tmp_path)
+    executor.update_parameters(oar_walltime="2:0:0")
+    assert executor._executor.parameters["walltime"] == "2:0:0"
+
+
+def test_update_parameters_error(tmp_path: Path) -> None:
+    with mocked_oar():
+        executor = oar.OarExecutor(folder=tmp_path)
+    with pytest.raises(ValueError):
+        executor.update_parameters(blublu=12)
+
+
+def test_read_info() -> None:
+    example = """{
+        "1924697" : {
+            "state" : "Running"
+        }
+    }"""
+    output = oar.OarInfoWatcher().read_info(example)
+    assert output["1924697"] == {"JobID": '1924697', "NodeList" : None, "State" : 'Running'}
+
+
+def test_watcher() -> None:
+    with mocked_oar() as mock:
+        watcher = oar.OarInfoWatcher()
+        mock.set_job_state("12", "Running")
+        assert watcher.num_calls == 0
+        state = watcher.get_state(job_id="11")
+        assert set(watcher._info_dict.keys()) == {"12"}
+        assert watcher._registered == {"11"}
+
+        assert state == "UNKNOWN"
+        mock.set_job_state("12", "FAILED")
+        state = watcher.get_state(job_id="12", mode="force")
+        assert state == "FAILED"
+        # TODO: this test is implementation specific. Not sure if we can rewrite it another way.
+        assert watcher._registered == {"11", "12"}
+        assert watcher._finished == {"12"}
+
+
+def test_get_default_parameters() -> None:
+    defaults = oar._get_default_parameters()
+    assert defaults["n"] == "submitit"
+
+
+def test_name() -> None:
+    assert oar.OarExecutor.name() == "oar"
+
+
+@contextlib.contextmanager
+def with_oar_job_nodefile(node_list: str) -> tp.Iterator[oar.OarJobEnvironment]:
+    node_file_path = Path(__file__).parent / "_oar_node_file.txt"
+    _mock_oar_node_file(node_file_path, node_list)
+    os.environ["OAR_JOB_ID"] = "1"
+    os.environ["OAR_NODEFILE"] = str(Path.joinpath(node_file_path))
+    yield oar.OarJobEnvironment()
+    del os.environ["OAR_NODEFILE"]
+    del os.environ["OAR_JOB_ID"]
+
+
+def _mock_oar_node_file(node_file_path, node_list: str) -> None:
+    """Write fake oar node file"""
+    with open(node_file_path, "w+") as file:
+        file.write(node_list)
+
+
+def test_oar_node_file() -> None:
+    with with_oar_job_nodefile('chetemi-7.lille.grid5000.fr\n') as env:
+        assert env.hostnames == ['chetemi-7.lille.grid5000.fr']
+        assert env.num_nodes == 1
+        assert env.node == 0
+    with with_oar_job_nodefile('chetemi-8.lille.grid5000.fr\nchetemi-8.lille.grid5000.fr\nchetemi-7.lille.grid5000.fr\nchetemi-7.lille.grid5000.fr\n') as env:
+        assert ["chetemi-7.lille.grid5000.fr", "chetemi-8.lille.grid5000.fr"] == env.hostnames
+        assert env.num_nodes == 2
+        assert env.node == 0
+
+
+@pytest.mark.parametrize("params", [{}, {"timeout_min": None}])  # type: ignore
+def test_oar_through_auto(params: tp.Dict[str, int], tmp_path: Path) -> None:
+    with mocked_oar():
+        executor = submitit.AutoExecutor(folder=tmp_path)
+        executor.update_parameters(**params, oar_additional_parameters={"t": 'besteffort'})
+        job = executor.submit(test_core.do_nothing, 1, 2, blublu=3)
+    text = job.paths.submission_file.read_text()
+    best_effort_lines = [x for x in text.splitlines() if "#OAR -t besteffort" in x]
+    assert len(best_effort_lines) == 1, f"Unexpected lines: {best_effort_lines}"
+
+
+def test_timeout_min_to_oar_walltime(tmp_path: Path) -> None:
+    with mocked_oar():
+        executor = submitit.AutoExecutor(folder=tmp_path)
+        executor.update_parameters(timeout_min=90)
+        job = executor.submit(test_core.do_nothing, 1, 2, blublu=3)
+    text = job.paths.submission_file.read_text()
+    walltime_lines = [x for x in text.splitlines() if "#OAR -l walltime=01:30" in x]
+    assert len(walltime_lines) == 1, f"Unexpected lines: {walltime_lines}"
+
+
+def test_oar_walltime_wins_over_timeout_min(tmp_path: Path) -> None:
+    with mocked_oar():
+        executor = submitit.AutoExecutor(folder=tmp_path)
+        executor.update_parameters(timeout_min=90, oar_walltime="2:0:0")
+        job = executor.submit(test_core.do_nothing, 1, 2, blublu=3)
+    text = job.paths.submission_file.read_text()
+    walltime_lines = [x for x in text.splitlines() if "#OAR -l walltime=2:0:0" in x]
+    assert len(walltime_lines) == 1, f"Unexpected lines: {walltime_lines}"

--- a/submitit/oar/test_oar.py
+++ b/submitit/oar/test_oar.py
@@ -45,7 +45,7 @@ class MockedSubprocess:
         return "\n".join(self.job_oarstat.values())
 
     def oarsub(self, args: Sequence[str]) -> str:
-        """Create a "Running" job."""
+        """Create a "RUNNING" job."""
         job_id = str(self.job_count)
         self.job_count += 1
         self.set_job_state(job_id, "Running", 0)
@@ -129,7 +129,7 @@ def test_oar_job_mocked(tmp_path: Path) -> None:
         job = executor.submit(test_core.do_nothing, 1, 2, blublu=3)
         # First mock job always have id 12
         assert job.job_id == "12"
-        assert job.state == "Running"
+        assert job.state == "RUNNING"
         assert job.stdout() is None
         _mock_log_files(job, errors="This is the error log\n", prints="hop")
         job._results_timeout_s = 0
@@ -237,7 +237,7 @@ def test_read_info() -> None:
         }
     }"""
     output = oar.OarInfoWatcher().read_info(example)
-    assert output["1924697"] == {"JobID": '1924697', "NodeList" : None, "State" : 'Running'}
+    assert output["1924697"] == {"JobID": '1924697', "NodeList" : None, "State" : 'RUNNING'}
 
 
 def test_watcher() -> None:
@@ -250,7 +250,7 @@ def test_watcher() -> None:
         assert watcher._registered == {"11"}
 
         assert state == "UNKNOWN"
-        mock.set_job_state("12", "FAILED")
+        mock.set_job_state("12", "Error")
         state = watcher.get_state(job_id="12", mode="force")
         assert state == "FAILED"
         # TODO: this test is implementation specific. Not sure if we can rewrite it another way.


### PR DESCRIPTION
The [Oar](https://oar.imag.fr/) scheduler is widely used in France, including mesocentre supercomputers (e.g., GRICAD), [INRIA](https://www.inria.fr/en) supercomputers, [Grid5000 testbed](https://www.grid5000.fr/w/Grid5000:Home) and other plateforms.

This PR adds support for the OAR Scheduler as a plugin. Four main classes have been implemented in `oar.py` (following the previous implementation made for slurm):
* **OarInfoWatcher**: Retrieves job status using the `oarstat` command (similar to the `sinfo` command on the Slurm scheduler).
* **OarJob**: Represents an OAR job. 
* **OarExecutor**: Contains the parameters to submit a job on OAR.
* **OarJobEnvironment**: Provides mappings with OAR environment variables such as job_id, nodes or array_task_id.

Unit tests were created in `test_oar.py` and `test_auto.py` to ensure that the OAR plugin offers the same basic functionalities as the Slurm plugin. 

A few notes about the implementation:
* In the **OarExecutor** class, OAR parameters are matched with those of submitit (using  the `_equivalence_dict` dictionary). Additional OAR parameters can be set with the `additional_parameters` dictionary.
* As the OAR submission file must exist at both the submission time **AND** at the job launch time (not the case for Slurm), the `_make_submission_command` method in the **OarExecutor** class is overridden from PicklingExecutor. The content of the file is read and the job is submitted using the **OAR "inline command"** instead of using the submission file.
* OAR job state names differ from the Submitit ones. We map the OAR state names to the submitit ones to unify status accros plugins.
* Resuming preempted jobs differ between OAR and Slurm. The OAR equivalent command for `scontrol` (i.e., `oarsub`) is not available on nodes. To automatically requeue the job after preemption, the original job must be submitted with the `idempotent` type and be exited with the `99` code.
* For job arrays, OAR does not provide a feature to limit the number of concurrently executed jobs so we could not implement that.

Our implemented OAR plugin covers most of submitit features (e.g., job submission, checkpointing, job array). The only feature that we did not address is the task submission. Indeed, contrary to Slurm, OAR does not provide such a feature. We believe a workaround could be implemented in another iteration. Meanwhile, we raise a "NotImplemeted" error if a user attempts to use such a feature.