### PR TITLE
Add an option for not using srun

### DIFF
--- a/submitit/core/submission.py
+++ b/submitit/core/submission.py
@@ -58,7 +58,7 @@ def process_job(folder: Union[Path, str]) -> None:
         with utils.temporary_save_path(paths.result_pickle) as tmppath:  # save somewhere else, and move
             utils.cloudpickle_dump(("success", result), tmppath)
             del result
-            logger.info("Exitting after successful completion")
+            logger.info("Exiting after successful completion")
     except Exception as error:  # TODO: check pickle methods for capturing traceback; pickling and raising
         try:
             with utils.temporary_save_path(paths.result_pickle) as tmppath:

--- a/submitit/helpers.py
+++ b/submitit/helpers.py
@@ -312,7 +312,7 @@ def clean_env() -> tp.Iterator[None]:
     cluster_env = {
         x: os.environ.pop(x)
         for x in os.environ
-        if x.startswith(("SLURM_", "SUBMITIT_")) or x in distrib_names
+        if x.startswith(("SLURM_", "SLURMD_", "SRUN_", "SBATCH_", "SUBMITIT_")) or x in distrib_names
     }
     try:
         yield

--- a/submitit/slurm/slurm.py
+++ b/submitit/slurm/slurm.py
@@ -152,7 +152,7 @@ def _parse_node_group(node_list: str, pos: int, parsed: List[str]) -> int:
             return pos + 1
         if c == "[":
             last_pos = node_list.index("]", pos)
-            suffixes = _expand_id_suffix(node_list[pos + 1: last_pos])
+            suffixes = _expand_id_suffix(node_list[pos + 1 : last_pos])
             prefixes = [prefix + suffix for prefix in prefixes for suffix in suffixes]
             pos = last_pos + 1
         else:
@@ -382,7 +382,7 @@ class SlurmExecutor(core.PicklingExecutor):
 def _get_default_parameters() -> Dict[str, Any]:
     """Parameters that can be set through update_parameters"""
     specs = inspect.getfullargspec(_make_sbatch_string)
-    zipped = zip(specs.args[-len(specs.defaults):], specs.defaults)  # type: ignore
+    zipped = zip(specs.args[-len(specs.defaults) :], specs.defaults)  # type: ignore
     return {key: val for key, val in zipped if key not in {"command", "folder", "map_count"}}
 
 

--- a/submitit/slurm/slurm.py
+++ b/submitit/slurm/slurm.py
@@ -463,7 +463,7 @@ def _make_sbatch_string(
         "signal_delay_s",
         "stderr_to_stdout",
         "srun_args",
-        "use_srun",
+        "use_srun",  # if False, un python directly in sbatch instead of through srun
     ]
     parameters = {k: v for k, v in locals().items() if v is not None and k not in nonslurm}
     # rename and reformat parameters
@@ -502,6 +502,9 @@ def _make_sbatch_string(
     # We pass --output and --error here, because the SBATCH command doesn't work as expected with a filename pattern
 
     if use_srun:
+        # using srun has been the only option historically,
+        # but it's not clear anymore if it is necessary, and using it prevents
+        # jobs from scheduling other jobs
         stderr_flags = [] if stderr_to_stdout else ["--error", stderr]
         if srun_args is None:
             srun_args = []


### PR DESCRIPTION
`srun` is not necessary in the batch file, and I am not sure what it brings.
In the last slurm versions, using `srun` in a job submitted with `srun` triggers invalid resource errors.

Removing srun on the other hand make everything work just fine, this was tested and working on a real test case. This adds a "use_srun" parameter which is True as a default for the time being, so old pipelines won't be impacted, while it enables new pipelines to have more flexibility.
