### PR TITLE
Make local job instances picklable

### DIFF
--- a/submitit/local/local.py
+++ b/submitit/local/local.py
@@ -268,9 +268,8 @@ class Controller:
         self.folder = Path(folder)
         signal.signal(signal.SIGTERM, self._forward_signal)  # type: ignore
 
-    def _forward_signal(
-        self, signum: signal.Signals, *args: tp.Any
-    ) -> None:  # pylint:disable=unused-argument
+    # pylint:disable=unused-argument
+    def _forward_signal(self, signum: signal.Signals, *args: tp.Any) -> None:
         for task in self.tasks:
             try:
                 task.send_signal(signum)  # sending kill signal to make sure everything finishes

--- a/submitit/local/local.py
+++ b/submitit/local/local.py
@@ -38,7 +38,7 @@ class LocalJob(core.Job[R]):
         self._sub_jobs: tp.Sequence["LocalJob[R]"] = self._sub_jobs
         # set process (to self and subjobs)
         if process is not None:
-            for sjob in [self] + self._sub_jobs:
+            for sjob in [self] + list(self._sub_jobs):
                 PROCESSES[sjob.job_id] = process
 
     def done(self, force_check: bool = False) -> bool:  # pylint: disable=unused-argument

--- a/submitit/local/local.py
+++ b/submitit/local/local.py
@@ -21,6 +21,8 @@ VALID_KEYS = {"timeout_min", "gpus_per_node", "tasks_per_node", "signal_delay_s"
 
 LOCAL_REQUEUE_RETURN_CODE = 144
 
+# global variable storing unfinished processes of pickled jobs
+# in case we need to reload them later
 _PROCESSES = {}
 
 

--- a/submitit/local/local.py
+++ b/submitit/local/local.py
@@ -147,7 +147,7 @@ class LocalExecutor(core.PicklingExecutor):
     job_class = LocalJob
 
     def __init__(
-        self, folder: Union[str, Path], max_num_timeout: int = 3, python: Optional[str] = None
+        self, folder: tp.Union[str, Path], max_num_timeout: int = 3, python: tp.Optional[str] = None
     ) -> None:
         super().__init__(folder, max_num_timeout=max_num_timeout)
         self.python = shlex.quote(sys.executable) if python is None else python

--- a/submitit/local/local.py
+++ b/submitit/local/local.py
@@ -87,7 +87,6 @@ class LocalJob(core.Job[R]):
         if self._cancel_at_deletion:
             if not self.get_info().get("jobState") == "FINISHED":
                 self.cancel(check=False)
-            _PROCESSES.pop(self.job_id, None)
         # let's clear the process dict if we know it's finished
         if self.paths.result_pickle.exists():
             _PROCESSES.pop(self.job_id, None)

--- a/submitit/local/test_local.py
+++ b/submitit/local/test_local.py
@@ -50,7 +50,7 @@ def test_local_job(tmp_path: Path) -> None:
     # single task job is a regular job
     assert job2.task(0) is job2
     assert job2.done()
-    # pickelability
+    # picklability
     b = pickle.dumps(job2)
     job3 = pickle.loads(b)
     assert job3.results() == [0]


### PR DESCRIPTION
Benefit(s?):
- makes `LocalJob` picklable, which can be convenient in many pipelines (+ other jobs are picklable)

Drawbacks:
- There is an additional global variable to store running processes
- If we lose the process handle (reloading from somewhere else) we may not know the status of the job (when no result file is created)
-  the PR is breaking the internal API, but that should not be used externally (we could do a non-breaking change, but I'd rather keep a `_process()` function as it's clearer that it's not an attribute completely owned by the job)

I think the benefit outweighs the drawbacks which are not really cumbersome