### PR TITLE
Allow hiding extra env variables in clean_env()

### DIFF
--- a/submitit/helpers.py
+++ b/submitit/helpers.py
@@ -293,14 +293,14 @@ def monitor_jobs(
 
 
 @contextlib.contextmanager
-def clean_env(extra_names: tp.Optional[tp.Sequence[str]] = None) -> tp.Iterator[None]:
+def clean_env(extra_names: tp.Sequence[str] = ()) -> tp.Iterator[None]:
     """Removes slurm and submitit related environment variables so as to avoid interferences
     when submiting a new job from a job.
 
     Parameters
     ----------
     extra_names: Sequence[str]
-        An optional list of environment variables to hide inside the context,
+        Additional environment variables to hide inside the context,
         e.g. TRITON_CACHE_DIR and TORCHINDUCTOR_CACHE_DIR when using torch.compile.
 
     Note
@@ -314,8 +314,6 @@ def clean_env(extra_names: tp.Optional[tp.Sequence[str]] = None) -> tp.Iterator[
     with submitit.helpers.clean_env():
         executor.submit(...)
     """
-    if extra_names is None:
-        extra_names = ()
     distrib_names = ("MASTER_ADDR", "MASTER_PORT", "RANK", "WORLD_SIZE", "LOCAL_RANK", "LOCAL_WORLD_SIZE")
     cluster_env = {
         x: os.environ.pop(x)

--- a/submitit/test_helpers.py
+++ b/submitit/test_helpers.py
@@ -144,3 +144,8 @@ def test_clean_env() -> None:
             assert not _get_env()
         assert len(_get_env()) == len(base) + 2
     assert _get_env() == base
+
+    with utils.environment_variables(MASTER_PORT=42, BLABLA=314):
+        with helpers.clean_env(extra_names=("BLABLA",)):
+            assert "MASTER_PORT" not in os.environ
+            assert "BLABLA" not in os.environ


### PR DESCRIPTION
**Context:** my training job, running in SLURM, periodically submits evaluation jobs, also to be run in SLURM. Both training and evaluation jobs make use of `torch.compile()` which in turn enables torchinductor and triton.

**Problem:** at the first use, torchinductor and triton set the `TRITON_CACHE_DIR` and `TORCHINDUCTOR_CACHE_DIR` environment variables to indicate the location of their cache dirs. When an evaluation job is submitted, it inherits these variables, it tries to access those folders and gets a permission error:
```
torch._dynamo.exc.BackendCompilerFailed: backend='inductor' raised:
PermissionError: [Errno 13] Permission denied: '/scratch/slurm_tmpdir/4187753'
...
srun: error: hostname1058: tasks 0,2-7: Exited with exit code 1
srun: Terminating StepId=4197552.0
slurmstepd: error: *** STEP 4197552.0 ON hostname1058 CANCELLED AT 2024-07-25T22:08:52 ***
srun: error: hostname1058: task 1: Exited with exit code 1
```

Note that the job id of the evaluation job is `4197552` but it tries to access `/scratch/slurm_tmpdir/4187753` that is the cache dir derived from the parent training job `4187753`.

**Proposed solution:** submitit already exposes the `clean_env()` context manager to allow hiding some variables when submitting jobs programmatically from within another job. It's easy to add a parameter to `clean_env()` to allow users to hide additional variables that are relevant for their case.

Variable names and docstring are open to suggestions.