### PR TITLE
Consider PREEMPTED state as "not done"

### DIFF
--- a/submitit/core/core.py
+++ b/submitit/core/core.py
@@ -100,7 +100,7 @@ class InfoWatcher:
             one of "force" (forces a call), "standard" (calls regularly) or "cache" (does not call)
         """
         state = self.get_state(job_id, mode=mode)
-        return state.upper() not in ["READY", "PENDING", "RUNNING", "UNKNOWN", "REQUEUED", "COMPLETING"]
+        return state.upper() not in ["READY", "PENDING", "RUNNING", "UNKNOWN", "REQUEUED", "COMPLETING", "PREEMPTED"]
 
     def update_if_long_enough(self, mode: str) -> None:
         """Updates if forced to, or if the delay is reached


### PR DESCRIPTION
Hi all,

Here is a proposed patch for something that we ran into internally. I have a note on testing below. Let me know if there is anything I can do to improve this or test further. Thank you!

Currently if a job is preempted, submitit considers the job as failed, because it does not find the pickle file and PREEMPTED is currently considered to signal that a job is "done".

In reality it will either requeue (in which case it is not done) or it will eventually transition to CANCELLED (in which case submitit will detect it later anyway.

### Testing
I have tested this internally, but am also happy to test it with the test suite you have provided, but unfortunately I get a few failures both before and after my change pasted below: 
```
=================================== short test summary info ====================================
FAILED submitit/local/test_local.py::test_requeuing - AssertionError: Should have resumed from a checkpoint:
FAILED submitit/local/test_local.py::test_custom_checkpoint - AssertionError: assert ''
FAILED submitit/test_helpers.py::test_as_completed - assert 7.915418386459351 < 1.5
FAILED submitit/core/test_utils.py::test_command_function_deadlock - submitit.core.utils.UncompletedJobError: Job 1714748 (task: 0) with path /tmp/pytest-of-dok...
============== 4 failed, 118 passed, 2 skipped, 3 xfailed, 144 warnings in 36.43s ==============
make: *** [Makefile:21: test] Error 1
```