### PR TITLE
Keep original tmp slurm submission file as a hidden symlink 

### DIFF
--- a/submitit/__init__.py
+++ b/submitit/__init__.py
@@ -18,4 +18,4 @@ from .local.local import LocalJob as LocalJob
 from .slurm.slurm import SlurmExecutor as SlurmExecutor
 from .slurm.slurm import SlurmJob as SlurmJob
 
-__version__ = "1.5.1"
+__version__ = "1.5.2"

--- a/submitit/core/core.py
+++ b/submitit/core/core.py
@@ -925,7 +925,7 @@ class PicklingExecutor(Executor):
         """
         tmp_uuid = uuid.uuid4().hex
         submission_file_path = (
-            utils.JobPaths.get_first_id_independent_folder(self.folder) / f"submission_file_{tmp_uuid}.sh"
+            utils.JobPaths.get_first_id_independent_folder(self.folder) / f".submission_file_{tmp_uuid}.sh"
         )
         with submission_file_path.open("w") as f:
             f.write(self._make_submission_file_text(command, tmp_uuid))
@@ -935,7 +935,7 @@ class PicklingExecutor(Executor):
         job_id = self._get_job_id_from_submission_command(output)
         tasks_ids = list(range(self._num_tasks()))
         job: Job[tp.Any] = self.job_class(folder=self.folder, job_id=job_id, tasks=tasks_ids)
-        job.paths.move_temporary_file(submission_file_path, "submission_file")
+        job.paths.copy_temporary_file(submission_file_path, "submission_file")
         self._write_job_id(job.job_id, tmp_uuid)
         self._set_job_permissions(job.paths.folder)
         return job

--- a/submitit/core/core.py
+++ b/submitit/core/core.py
@@ -925,7 +925,7 @@ class PicklingExecutor(Executor):
         """
         tmp_uuid = uuid.uuid4().hex
         submission_file_path = (
-            utils.JobPaths.get_first_id_independent_folder(self.folder) / f"submission_file_{tmp_uuid}.sh"
+            utils.JobPaths.get_first_id_independent_folder(self.folder) / f".submission_file_{tmp_uuid}.sh"
         )
         with submission_file_path.open("w") as f:
             f.write(self._make_submission_file_text(command, tmp_uuid))

--- a/submitit/core/core.py
+++ b/submitit/core/core.py
@@ -925,7 +925,7 @@ class PicklingExecutor(Executor):
         """
         tmp_uuid = uuid.uuid4().hex
         submission_file_path = (
-            utils.JobPaths.get_first_id_independent_folder(self.folder) / f".submission_file_{tmp_uuid}.sh"
+            utils.JobPaths.get_first_id_independent_folder(self.folder) / f"submission_file_{tmp_uuid}.sh"
         )
         with submission_file_path.open("w") as f:
             f.write(self._make_submission_file_text(command, tmp_uuid))
@@ -935,7 +935,7 @@ class PicklingExecutor(Executor):
         job_id = self._get_job_id_from_submission_command(output)
         tasks_ids = list(range(self._num_tasks()))
         job: Job[tp.Any] = self.job_class(folder=self.folder, job_id=job_id, tasks=tasks_ids)
-        job.paths.copy_temporary_file(submission_file_path, "submission_file")
+        job.paths.move_temporary_file(submission_file_path, "submission_file", keep_as_symlink=True)
         self._write_job_id(job.job_id, tmp_uuid)
         self._set_job_permissions(job.paths.folder)
         return job

--- a/submitit/core/utils.py
+++ b/submitit/core/utils.py
@@ -97,6 +97,10 @@ class JobPaths:
         self.folder.mkdir(parents=True, exist_ok=True)
         Path(tmp_path).rename(getattr(self, name))
 
+    def copy_temporary_file(self, tmp_path: tp.Union[Path, str], name: str) -> None:
+        self.folder.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(tmp_path, getattr(self, name))
+
     @staticmethod
     def get_first_id_independent_folder(folder: tp.Union[Path, str]) -> Path:
         """Returns the closest folder which is id independent"""

--- a/submitit/core/utils.py
+++ b/submitit/core/utils.py
@@ -93,13 +93,11 @@ class JobPaths:
             replaced_path = replaced_path.replace("%a", array_index[0])
         return Path(replaced_path.replace("%A", array_id))
 
-    def move_temporary_file(self, tmp_path: tp.Union[Path, str], name: str) -> None:
+    def move_temporary_file(self, tmp_path: tp.Union[Path, str], name: str, keep_as_symlink: bool = False) -> None:
         self.folder.mkdir(parents=True, exist_ok=True)
         Path(tmp_path).rename(getattr(self, name))
-
-    def copy_temporary_file(self, tmp_path: tp.Union[Path, str], name: str) -> None:
-        self.folder.mkdir(parents=True, exist_ok=True)
-        shutil.copyfile(tmp_path, getattr(self, name))
+        if keep_as_symlink:
+            Path(tmp_path).symlink_to(getattr(self, name))
 
     @staticmethod
     def get_first_id_independent_folder(folder: tp.Union[Path, str]) -> Path:


### PR DESCRIPTION
# Why making this change? 
if we do "scontrol show job", we get the submission scripts pointed to the temporary submission file which got removed, 
e.g: 
```
(jepa) [xiaodongma@rsccpu4035 xiaodongma]$ scontrol show job 4499193
JobId=4499203 JobName=xiaodongma
  ...
   Command=/home/xiaodongma/jepa-internal/xiaodongma/submission_file_e9c4eef46a24436b81d5213875f19d6c.sh
...
```

this can bring confusion to slurm ecosystem and make it hard to integration with other tooling that relies on parsing/post-inspecting the sbatch script. 

# Fix
This diff create the temporary submission file as a symlink to the moved submission file

# Test
after fix, we can see the submission file 
```
scontrol show job 4499203
JobId=4499203 JobName=xiaodongma
... Command=/checkpoint/amaia/video/xiaodongma/vjepav3/arch/vjepav1/vit.l.16.m8/.submission_file_bb581d4ec3954cd9a45aa7388ad6494e.sh
...
(jepa) xiaodongma@xiaodongma-login-0:/checkpoint/amaia/video/xiaodongma/vjepav3/arch/vjepav1/vit.l.16.m8$ ll /checkpoint/amaia/video/xiaodongma/vjepav3/arch/vjepav1/vit.l.16.m8/.submission_file_bb581d4ec3954cd9a45aa7388ad6494e.sh
lrwxrwxrwx 1 xiaodongma fair_amaia_cw_video 101 Sep 17 17:48 /checkpoint/amaia/video/xiaodongma/vjepav3/arch/vjepav1/vit.l.16.m8/.submission_file_bb581d4ec3954cd9a45aa7388ad6494e.sh -> /checkpoint/amaia/video/xiaodongma/vjepav3/arch/vjepav1/vit.l.16.m8/job_1358522/1358522_submission.sh
```
