### PR TITLE
Add optional teardown command to SlurmExecutor

### DIFF
--- a/submitit/slurm/slurm.py
+++ b/submitit/slurm/slurm.py
@@ -446,6 +446,8 @@ def _make_sbatch_string(
         delay between the kill signal and the actual kill of the slurm job.
     setup: list
         a list of command to run in sbatch before running srun
+    teardown: list
+        a list of command to run in sbatch after running srun
     map_size: int
         number of simultaneous map/array jobs allowed
     additional_parameters: dict
@@ -469,6 +471,7 @@ def _make_sbatch_string(
         "array_parallelism",
         "additional_parameters",
         "setup",
+        "teardown",
         "signal_delay_s",
         "stderr_to_stdout",
         "srun_args",
@@ -529,6 +532,7 @@ def _make_sbatch_string(
         "",
     ]
 
+    # environment teardown:
     if teardown is not None:
         lines += ["", "# teardown"] + teardown
     return "\n".join(lines)

--- a/submitit/slurm/slurm.py
+++ b/submitit/slurm/slurm.py
@@ -408,6 +408,7 @@ def _make_sbatch_string(
     gpus_per_task: tp.Optional[int] = None,
     qos: tp.Optional[str] = None,  # quality of service
     setup: tp.Optional[tp.List[str]] = None,
+    teardown: tp.Optional[tp.List[str]] = None,
     mem: tp.Optional[str] = None,
     mem_per_gpu: tp.Optional[str] = None,
     mem_per_cpu: tp.Optional[str] = None,
@@ -527,6 +528,9 @@ def _make_sbatch_string(
         command,
         "",
     ]
+
+    if teardown is not None:
+        lines += ["", "# teardown"] + teardown
     return "\n".join(lines)
 
 

--- a/submitit/slurm/test_slurm.py
+++ b/submitit/slurm/test_slurm.py
@@ -517,3 +517,13 @@ def test_slurm_job_no_stderr(tmp_path: Path) -> None:
         # job.paths.stdout.unlink()
         with pytest.raises(utils.UncompletedJobError, match="No output/error stream produced !"):
             job._get_outcome_and_result()
+
+def test_slurm_through_auto_with_setup_and_teardown(tmp_path: Path) -> None:
+    with mocked_slurm():
+        executor = submitit.AutoExecutor(folder=tmp_path)
+        executor.update_parameters(slurm_additional_parameters={"mem_per_gpu": 12}, slurm_setup=["This is a setup command"],
+                                          slurm_teardown=["This is a teardown command"])
+        job = executor.submit(test_core.do_nothing, 1, 2, blublu=3)
+    text = job.paths.submission_file.read_text()
+    assert "This is a setup command" in text
+    assert "This is a teardown command" in text


### PR DESCRIPTION
Some SLURM clusters require additional work after the python command is done such as node cleanup etc. This PR adds the option to specify commands after the main command is run and adds a test case for both the setup and the new teardown functionality.

Sidenote: The pytest runs through for all added changes, but there is currently a problem with the "pkg_resources" package that makes the test suite and the linting as described in the contribution guidelines not run.