### PR TITLE
calculating proportionate resources with clusterscope

### DIFF
--- a/docs/checkpointing.md
+++ b/docs/checkpointing.md
@@ -79,10 +79,16 @@ submitted to a slurm job, which will be checkpointed and requeued at most `slurm
 (and any number of time if preempted):
 ```python
 import submitit
+import clusterscope
 from .network import NetworkTraining  # must be defined in an importable module!
 executor = submitit.AutoExecutor(folder="logs_training", slurm_max_num_timeout=3)
-executor.update_parameters(timeout_min=30, slurm_partition="your_partition",
-                           gpus_per_node=1, cpus_per_task=2)
+slurm_partition = "your_partition"
+# clusterscope assigns the proportionate amount of resources based on gpus/cpus being requested.
+resources = clusterscope.job_gen_task_slurm(partition=slurm_partition, gpus_per_task=1, tasks_per_node=1)
+executor.update_parameters(timeout_min=30,
+                           slurm_partition=slurm_partition,
+                           gpus_per_node=resources["gpus_per_task"] * resources["tasks_per_node"],
+                           cpus_per_task=resources["cpus_per_task"])
 training_callable = NetworkTraining()
 job = executor.submit(training_callable, "some/path/for/checkpointing/your/network")
 ```

--- a/docs/checkpointing.md
+++ b/docs/checkpointing.md
@@ -88,7 +88,8 @@ resources = clusterscope.job_gen_task_slurm(partition=slurm_partition, gpus_per_
 executor.update_parameters(timeout_min=30,
                            slurm_partition=slurm_partition,
                            gpus_per_node=resources["gpus_per_task"] * resources["tasks_per_node"],
-                           cpus_per_task=resources["cpus_per_task"])
+                           cpus_per_task=resources["cpus_per_task"],
+                           mem_gb=resources["mem_gb"])
 training_callable = NetworkTraining()
 job = executor.submit(training_callable, "some/path/for/checkpointing/your/network")
 ```

--- a/docs/examples/torch_distributed.py
+++ b/docs/examples/torch_distributed.py
@@ -80,6 +80,7 @@ def main():
         gpus_per_node=gpus_per_node,
         tasks_per_node=tasks_per_node,
         cpus_per_task=resources["cpus_per_task"],
+        mem_gb=resources["mem_gb"],
         slurm_partition=PARTITION,
     )
     task = Task()

--- a/docs/examples/torch_distributed.py
+++ b/docs/examples/torch_distributed.py
@@ -10,6 +10,7 @@ import os
 import sys
 import time
 
+import clusterscope
 import torch
 
 import submitit
@@ -69,11 +70,16 @@ class Task:
 
 def main():
     executor = submitit.AutoExecutor(folder=LOGS_DIR)
+    gpus_per_node = NUM_TASKS_PER_NODE
+    tasks_per_node = NUM_TASKS_PER_NODE
+    gpus_per_task = gpus_per_node // tasks_per_node
+    # clusterscope assigns the proportionate amount of resources based on gpus/cpus being requested.
+    resources = clusterscope.job_gen_task_slurm(partition=PARTITION, gpus_per_task=gpus_per_task)
     executor.update_parameters(
         nodes=NUM_NODES,
-        gpus_per_node=NUM_TASKS_PER_NODE,
-        tasks_per_node=NUM_TASKS_PER_NODE,
-        cpus_per_task=NUM_CPUS_PER_TASK,
+        gpus_per_node=gpus_per_node,
+        tasks_per_node=tasks_per_node,
+        cpus_per_task=resources["cpus_per_task"],
         slurm_partition=PARTITION,
     )
     task = Task()

--- a/docs/mnist.py
+++ b/docs/mnist.py
@@ -10,6 +10,7 @@ import pickle
 import time
 from pathlib import Path
 
+import clusterscope
 import numpy as np
 from sklearn.datasets import fetch_openml
 from sklearn.linear_model import LogisticRegression
@@ -125,7 +126,14 @@ def main():
     # Specify the job requirements.
     # Reserving only as much resource as you need ensure the cluster resource are
     # efficiently allocated.
-    ex.update_parameters(mem_gb=1, cpus_per_task=4, timeout_min=5)
+    resources = {
+        "cpus_per_task": 4,
+        "mem_gb": 1,
+    }
+    if ex.slurm_partition:
+        # clusterscope assigns the proportionate amount of resources based on gpus/cpus being requested.
+        resources = clusterscope.job_gen_task_slurm(partition=ex.slurm_partition, cpus_per_task=4)
+    ex.update_parameters(mem_gb=resources["mem_gb"], cpus_per_task=resources["cpus_per_task"], timeout_min=5)
     job = ex.submit(trainer, 5000, model_path=model_path)
 
     print(f"Scheduled {job}.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dynamic = ["version", "description"]
 
 dependencies = [
   "cloudpickle>=1.2.1",
+  "clusterscope",
   "typing_extensions>=3.7.4.2"
 ]
 # zip_safe = false


### PR DESCRIPTION
[clusterscope](https://github.com/facebookresearch/clusterscope/) has an API to calculate proportionate resource usage in the machine (CPUs / Mem) given the number of GPUs or CPUs.

that is, for GPU requests:

if a slurm partition has nodes with 8 gpus, 80 cpus, 80GB; and a user ask for a single gpu:

```
>>> resources = clusterscope.job_gen_task_slurm(gpus_per_task=1, partition=...)
```
clusterscope returns a dict with 10 cpus (1/8 gpus * 80 cpus) and 10GB (1/8 gpus * 80GB) assigned:
```
>>> resources
{'cpus_per_task': 10, 'memory': '10G', 'tasks_per_node': 1, 'mem_gb': 10', slurm_partition': 'h100', ...}
```
notice how this dict allocates the proportionate amount of cpus and mem based on the number of gpus in the request.